### PR TITLE
feat: define core job types and worker contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kairos
 
-Kairos is a durable background job library for Gleam on the BEAM, inspired by Oban's reliability model but designed around Gleam's typed, explicit mental model.
+Kairos is a durable background job library for Gleam on the BEAM, designed around typed job contracts, explicit serialization boundaries, and operational clarity.
 
 Kairos is in early `0.x` development. The package API and runtime behavior are still being established.
 

--- a/src/kairos/job.gleam
+++ b/src/kairos/job.gleam
@@ -1,3 +1,9 @@
+//// Core job domain types for Kairos.
+////
+//// This module defines the public types used to describe job state and
+//// enqueue configuration.
+
+/// The states a job can move through during its lifecycle.
 pub type JobState {
   Pending
   Scheduled
@@ -8,10 +14,12 @@ pub type JobState {
   Cancelled
 }
 
+/// The scheduling strategy for a job.
 pub type Schedule {
   Immediately
 }
 
+/// The enqueue options for a job definition or enqueue request.
 pub opaque type EnqueueOptions {
   EnqueueOptions(
     queue: String,
@@ -21,6 +29,7 @@ pub opaque type EnqueueOptions {
   )
 }
 
+/// Returns the default enqueue options.
 pub fn default_enqueue_options() -> EnqueueOptions {
   EnqueueOptions(
     queue: "default",
@@ -30,21 +39,25 @@ pub fn default_enqueue_options() -> EnqueueOptions {
   )
 }
 
+/// Returns the configured queue name.
 pub fn queue(options: EnqueueOptions) -> String {
   let EnqueueOptions(queue:, ..) = options
   queue
 }
 
+/// Returns the configured maximum number of attempts.
 pub fn max_attempts(options: EnqueueOptions) -> Int {
   let EnqueueOptions(max_attempts:, ..) = options
   max_attempts
 }
 
+/// Returns the configured priority.
 pub fn priority(options: EnqueueOptions) -> Int {
   let EnqueueOptions(priority:, ..) = options
   priority
 }
 
+/// Returns the configured scheduling strategy.
 pub fn schedule(options: EnqueueOptions) -> Schedule {
   let EnqueueOptions(schedule:, ..) = options
   schedule

--- a/src/kairos/job.gleam
+++ b/src/kairos/job.gleam
@@ -1,0 +1,51 @@
+pub type JobState {
+  Pending
+  Scheduled
+  Executing
+  Retryable
+  Completed
+  Discarded
+  Cancelled
+}
+
+pub type Schedule {
+  Immediately
+}
+
+pub opaque type EnqueueOptions {
+  EnqueueOptions(
+    queue: String,
+    max_attempts: Int,
+    priority: Int,
+    schedule: Schedule,
+  )
+}
+
+pub fn default_enqueue_options() -> EnqueueOptions {
+  EnqueueOptions(
+    queue: "default",
+    max_attempts: 20,
+    priority: 0,
+    schedule: Immediately,
+  )
+}
+
+pub fn queue(options: EnqueueOptions) -> String {
+  let EnqueueOptions(queue:, ..) = options
+  queue
+}
+
+pub fn max_attempts(options: EnqueueOptions) -> Int {
+  let EnqueueOptions(max_attempts:, ..) = options
+  max_attempts
+}
+
+pub fn priority(options: EnqueueOptions) -> Int {
+  let EnqueueOptions(priority:, ..) = options
+  priority
+}
+
+pub fn schedule(options: EnqueueOptions) -> Schedule {
+  let EnqueueOptions(schedule:, ..) = options
+  schedule
+}

--- a/src/kairos/job.gleam
+++ b/src/kairos/job.gleam
@@ -3,7 +3,6 @@
 //// This module defines the public types used to describe job state and
 //// enqueue configuration.
 
-/// The states a job can move through during its lifecycle.
 pub type JobState {
   Pending
   Scheduled
@@ -14,12 +13,10 @@ pub type JobState {
   Cancelled
 }
 
-/// The scheduling strategy for a job.
 pub type Schedule {
   Immediately
 }
 
-/// The enqueue options for a job definition or enqueue request.
 pub opaque type EnqueueOptions {
   EnqueueOptions(
     queue: String,
@@ -29,7 +26,6 @@ pub opaque type EnqueueOptions {
   )
 }
 
-/// Returns the default enqueue options.
 pub fn default_enqueue_options() -> EnqueueOptions {
   EnqueueOptions(
     queue: "default",
@@ -39,25 +35,21 @@ pub fn default_enqueue_options() -> EnqueueOptions {
   )
 }
 
-/// Returns the configured queue name.
 pub fn queue(options: EnqueueOptions) -> String {
   let EnqueueOptions(queue:, ..) = options
   queue
 }
 
-/// Returns the configured maximum number of attempts.
 pub fn max_attempts(options: EnqueueOptions) -> Int {
   let EnqueueOptions(max_attempts:, ..) = options
   max_attempts
 }
 
-/// Returns the configured priority.
 pub fn priority(options: EnqueueOptions) -> Int {
   let EnqueueOptions(priority:, ..) = options
   priority
 }
 
-/// Returns the configured scheduling strategy.
 pub fn schedule(options: EnqueueOptions) -> Schedule {
   let EnqueueOptions(schedule:, ..) = options
   schedule

--- a/src/kairos/worker.gleam
+++ b/src/kairos/worker.gleam
@@ -1,0 +1,66 @@
+import kairos/job
+
+pub type DecodeError {
+  DecodeError(String)
+}
+
+pub type PerformResult {
+  Success
+  Retry(String)
+  Discard(String)
+  Cancel(String)
+}
+
+pub opaque type Worker(args) {
+  Worker(
+    name: String,
+    encoder: fn(args) -> String,
+    decoder: fn(String) -> Result(args, DecodeError),
+    performer: fn(args) -> PerformResult,
+    default_options: job.EnqueueOptions,
+  )
+}
+
+pub fn new(
+  name: String,
+  encoder: fn(args) -> String,
+  decoder: fn(String) -> Result(args, DecodeError),
+  performer: fn(args) -> PerformResult,
+  default_options: job.EnqueueOptions,
+) -> Worker(args) {
+  Worker(
+    name: name,
+    encoder: encoder,
+    decoder: decoder,
+    performer: performer,
+    default_options: default_options,
+  )
+}
+
+pub fn name(contract: Worker(args)) -> String {
+  let Worker(name:, ..) = contract
+  name
+}
+
+pub fn default_options(contract: Worker(args)) -> job.EnqueueOptions {
+  let Worker(default_options:, ..) = contract
+  default_options
+}
+
+pub fn encode(contract: Worker(args), args: args) -> String {
+  let Worker(encoder:, ..) = contract
+  encoder(args)
+}
+
+pub fn decode(
+  contract: Worker(args),
+  payload: String,
+) -> Result(args, DecodeError) {
+  let Worker(decoder:, ..) = contract
+  decoder(payload)
+}
+
+pub fn perform(contract: Worker(args), args: args) -> PerformResult {
+  let Worker(performer:, ..) = contract
+  performer(args)
+}

--- a/src/kairos/worker.gleam
+++ b/src/kairos/worker.gleam
@@ -5,12 +5,10 @@
 
 import kairos/job
 
-/// An error returned when a payload cannot be decoded.
 pub type DecodeError {
   DecodeError(String)
 }
 
-/// The result of executing a job.
 pub type PerformResult {
   Success
   Retry(String)
@@ -18,7 +16,6 @@ pub type PerformResult {
   Cancel(String)
 }
 
-/// A typed worker definition.
 pub opaque type Worker(args) {
   Worker(
     name: String,
@@ -29,7 +26,6 @@ pub opaque type Worker(args) {
   )
 }
 
-/// Creates a new worker definition.
 pub fn new(
   name: String,
   encoder: fn(args) -> String,
@@ -46,13 +42,11 @@ pub fn new(
   )
 }
 
-/// Returns the worker name.
 pub fn name(contract: Worker(args)) -> String {
   let Worker(name:, ..) = contract
   name
 }
 
-/// Returns the worker's default enqueue options.
 pub fn default_options(contract: Worker(args)) -> job.EnqueueOptions {
   let Worker(default_options:, ..) = contract
   default_options
@@ -73,7 +67,6 @@ pub fn decode(
   decoder(payload)
 }
 
-/// Executes the worker with typed arguments.
 pub fn perform(contract: Worker(args), args: args) -> PerformResult {
   let Worker(performer:, ..) = contract
   performer(args)

--- a/src/kairos/worker.gleam
+++ b/src/kairos/worker.gleam
@@ -1,9 +1,16 @@
+//// Typed worker contracts for Kairos jobs.
+////
+//// Worker definitions in this module encode typed arguments into a durable
+//// string payload and decode them again before execution.
+
 import kairos/job
 
+/// An error returned when a payload cannot be decoded.
 pub type DecodeError {
   DecodeError(String)
 }
 
+/// The result of executing a job.
 pub type PerformResult {
   Success
   Retry(String)
@@ -11,6 +18,7 @@ pub type PerformResult {
   Cancel(String)
 }
 
+/// A typed worker definition.
 pub opaque type Worker(args) {
   Worker(
     name: String,
@@ -21,6 +29,7 @@ pub opaque type Worker(args) {
   )
 }
 
+/// Creates a new worker definition.
 pub fn new(
   name: String,
   encoder: fn(args) -> String,
@@ -37,21 +46,25 @@ pub fn new(
   )
 }
 
+/// Returns the worker name.
 pub fn name(contract: Worker(args)) -> String {
   let Worker(name:, ..) = contract
   name
 }
 
+/// Returns the worker's default enqueue options.
 pub fn default_options(contract: Worker(args)) -> job.EnqueueOptions {
   let Worker(default_options:, ..) = contract
   default_options
 }
 
+/// Encodes worker arguments into a durable payload string.
 pub fn encode(contract: Worker(args), args: args) -> String {
   let Worker(encoder:, ..) = contract
   encoder(args)
 }
 
+/// Decodes a durable payload string into worker arguments.
 pub fn decode(
   contract: Worker(args),
   payload: String,
@@ -60,6 +73,7 @@ pub fn decode(
   decoder(payload)
 }
 
+/// Executes the worker with typed arguments.
 pub fn perform(contract: Worker(args), args: args) -> PerformResult {
   let Worker(performer:, ..) = contract
   performer(args)

--- a/test/kairos_job_test.gleam
+++ b/test/kairos_job_test.gleam
@@ -1,0 +1,37 @@
+import gleeunit
+import kairos/job
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+pub fn default_enqueue_options_test() {
+  let options = job.default_enqueue_options()
+
+  assert job.queue(options) == "default"
+  assert job.max_attempts(options) == 20
+  assert job.priority(options) == 0
+  assert job.schedule(options) == job.Immediately
+}
+
+pub fn job_state_variants_test() {
+  assert state_name(job.Pending) == "pending"
+  assert state_name(job.Scheduled) == "scheduled"
+  assert state_name(job.Executing) == "executing"
+  assert state_name(job.Retryable) == "retryable"
+  assert state_name(job.Completed) == "completed"
+  assert state_name(job.Discarded) == "discarded"
+  assert state_name(job.Cancelled) == "cancelled"
+}
+
+fn state_name(state: job.JobState) -> String {
+  case state {
+    job.Pending -> "pending"
+    job.Scheduled -> "scheduled"
+    job.Executing -> "executing"
+    job.Retryable -> "retryable"
+    job.Completed -> "completed"
+    job.Discarded -> "discarded"
+    job.Cancelled -> "cancelled"
+  }
+}

--- a/test/kairos_worker_test.gleam
+++ b/test/kairos_worker_test.gleam
@@ -1,0 +1,65 @@
+import gleeunit
+import kairos/job
+import kairos/worker
+
+type ExampleArgs {
+  ExampleArgs(name: String)
+}
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+pub fn worker_contract_test() {
+  let contract = example_worker()
+  let args = ExampleArgs(name: "kairos")
+
+  assert worker.name(contract) == "example"
+  assert worker.default_options(contract) == job.default_enqueue_options()
+  assert worker.encode(contract, args) == "kairos"
+  assert worker.decode(contract, "kairos") == Ok(args)
+  assert worker.perform(contract, args) == worker.Success
+}
+
+pub fn decode_error_test() {
+  let contract = example_worker()
+
+  assert worker.decode(contract, "")
+    == Error(worker.DecodeError("payload cannot be empty"))
+}
+
+pub fn perform_result_variants_test() {
+  assert result_name(worker.Success) == "success"
+  assert result_name(worker.Retry("retry later")) == "retry:retry later"
+  assert result_name(worker.Discard("discard permanently"))
+    == "discard:discard permanently"
+  assert result_name(worker.Cancel("cancel execution"))
+    == "cancel:cancel execution"
+}
+
+fn example_worker() -> worker.Worker(ExampleArgs) {
+  worker.new(
+    "example",
+    fn(args) {
+      let ExampleArgs(name:) = args
+      name
+    },
+    fn(payload) {
+      case payload {
+        "" -> Error(worker.DecodeError("payload cannot be empty"))
+        _ -> Ok(ExampleArgs(name: payload))
+      }
+    },
+    fn(_args) { worker.Success },
+    job.default_enqueue_options(),
+  )
+}
+
+fn result_name(result: worker.PerformResult) -> String {
+  case result {
+    worker.Success -> "success"
+    worker.Retry(reason) -> "retry:" <> reason
+    worker.Discard(reason) -> "discard:" <> reason
+    worker.Cancel(reason) -> "cancel:" <> reason
+  }
+}

--- a/test/kairos_worker_test.gleam
+++ b/test/kairos_worker_test.gleam
@@ -29,15 +29,37 @@ pub fn decode_error_test() {
 }
 
 pub fn perform_result_variants_test() {
-  assert result_name(worker.Success) == "success"
-  assert result_name(worker.Retry("retry later")) == "retry:retry later"
-  assert result_name(worker.Discard("discard permanently"))
-    == "discard:discard permanently"
-  assert result_name(worker.Cancel("cancel execution"))
-    == "cancel:cancel execution"
+  let args = ExampleArgs(name: "kairos")
+
+  assert worker.perform(success_worker(), args) == worker.Success
+  assert worker.perform(retry_worker(), args) == worker.Retry("retry later")
+  assert worker.perform(discard_worker(), args)
+    == worker.Discard("discard permanently")
+  assert worker.perform(cancel_worker(), args)
+    == worker.Cancel("cancel execution")
 }
 
 fn example_worker() -> worker.Worker(ExampleArgs) {
+  result_worker(worker.Success)
+}
+
+fn success_worker() -> worker.Worker(ExampleArgs) {
+  result_worker(worker.Success)
+}
+
+fn retry_worker() -> worker.Worker(ExampleArgs) {
+  result_worker(worker.Retry("retry later"))
+}
+
+fn discard_worker() -> worker.Worker(ExampleArgs) {
+  result_worker(worker.Discard("discard permanently"))
+}
+
+fn cancel_worker() -> worker.Worker(ExampleArgs) {
+  result_worker(worker.Cancel("cancel execution"))
+}
+
+fn result_worker(result: worker.PerformResult) -> worker.Worker(ExampleArgs) {
   worker.new(
     "example",
     fn(args) {
@@ -50,16 +72,7 @@ fn example_worker() -> worker.Worker(ExampleArgs) {
         _ -> Ok(ExampleArgs(name: payload))
       }
     },
-    fn(_args) { worker.Success },
+    fn(_args) { result },
     job.default_enqueue_options(),
   )
-}
-
-fn result_name(result: worker.PerformResult) -> String {
-  case result {
-    worker.Success -> "success"
-    worker.Retry(reason) -> "retry:" <> reason
-    worker.Discard(reason) -> "discard:" <> reason
-    worker.Cancel(reason) -> "cancel:" <> reason
-  }
 }


### PR DESCRIPTION
## Summary
- add the initial job state and enqueue option domain types
- introduce the typed worker contract with explicit string serialization boundaries
- add tests that pin the public API for enqueue defaults and worker behavior
- remove package-facing comparison language from the README

## Testing
- `gleam test`

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job lifecycle states and default enqueue configuration for managing jobs
  * Worker contracts with typed argument serialization, decoding, and execution results
  * Configurable enqueue options (queue, attempts, priority, schedule)

* **Tests**
  * Tests verifying enqueue defaults and job state representations
  * Tests covering worker contract behavior: encoding/decoding, decode errors, and perform result variants

* **Documentation**
  * README updated to emphasize typed job contracts, serialization boundaries, and operational clarity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->