### PR TITLE
Add PostgreSQL persistence primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,57 @@ Once the package is published, installation will be:
 gleam add kairos
 ```
 
+## PostgreSQL Schema
+
+Kairos ships PostgreSQL schema definitions through `kairos/postgres/schema`.
+Applications are expected to apply `schema.migrations()` in version order with their own migration runner.
+
+## PostgreSQL Setup
+
+The PostgreSQL integration suite expects:
+
+- a reachable PostgreSQL database
+- the `pgcrypto` extension to be available
+- a dedicated test database, referenced by `KAIROS_TEST_DATABASE_URL`
+
+The integration harness recreates `kairos_jobs`, so do not point `KAIROS_TEST_DATABASE_URL` at a shared development or production database.
+
+One local setup is:
+
+```sh
+createdb kairos_test
+export KAIROS_TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/kairos_test?sslmode=disable
+```
+
+## Existing Apps
+
+Kairos is a library, so the consuming application should own environment loading and pool supervision.
+For existing Gleam/OTP apps, the recommended shape is to read `DATABASE_URL` in the application layer, build a `pog.Config`, and start the pool in your supervision tree.
+
+```gleam
+import envoy
+import gleam/erlang/process.{type Name}
+import gleam/result
+import pog
+
+pub fn read_database_config(
+  pool_name: Name(pog.Message),
+) -> Result(pog.Config, Nil) {
+  use database_url <- result.try(envoy.get("DATABASE_URL"))
+  pog.url_config(pool_name, database_url)
+}
+```
+
+Then apply `schema.migrations()` with your existing migration runner and pass the resulting `pog.Connection` into the Kairos persistence modules.
+
+## Development Setup
+
+```sh
+gleam deps download
+createdb kairos_test
+export KAIROS_TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/kairos_test?sslmode=disable
+```
+
 ## Development
 
 ```sh

--- a/gleam.toml
+++ b/gleam.toml
@@ -4,7 +4,12 @@ description = "Durable background jobs for Gleam on the BEAM."
 repository = { type = "github", user = "ccarvalho-eng", repo = "kairos" }
 
 [dependencies]
+gleam_erlang = ">= 1.0.0 and < 2.0.0"
+gleam_otp = ">= 1.0.0 and < 2.0.0"
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_time = ">= 1.0.0 and < 2.0.0"
+pog = ">= 4.0.0 and < 5.0.0"
 
 [dev-dependencies]
+envoy = ">= 1.1.0 and < 2.0.0"
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,25 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "backoff", version = "1.1.6", build_tools = ["rebar3"], requirements = [], otp_app = "backoff", source = "hex", outer_checksum = "CF0CFFF8995FB20562F822E5CC47D8CCF664C5ECDC26A684CBE85C225F9D7C39" },
+  { name = "envoy", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "850DA9D29D2E5987735872A2B5C81035146D7FE19EFC486129E44440D03FD832" },
+  { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
   { name = "gleam_stdlib", version = "0.71.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "702F3BC2A14793906880B1078B19A6165F87323AEE8D0C4A34085846336FCAAE" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
   { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
+  { name = "opentelemetry_api", version = "1.5.0", build_tools = ["rebar3", "mix"], requirements = [], otp_app = "opentelemetry_api", source = "hex", outer_checksum = "F53EC8A1337AE4A487D43AC89DA4BD3A3C99DDF576655D071DEED8B56A2D5DDA" },
+  { name = "pg_types", version = "0.6.0", build_tools = ["rebar3"], requirements = [], otp_app = "pg_types", source = "hex", outer_checksum = "9949A4849DD13408FA249AB7B745E0D2DFDB9532AEE2B9722326E33CD082A778" },
+  { name = "pgo", version = "0.20.0", build_tools = ["rebar3"], requirements = ["backoff", "opentelemetry_api", "pg_types"], otp_app = "pgo", source = "hex", outer_checksum = "2F11E6649CEB38E569EF56B16BE1D04874AE5B11A02867080A2817CE423C683B" },
+  { name = "pog", version = "4.1.0", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_otp", "gleam_stdlib", "gleam_time", "pgo"], otp_app = "pog", source = "hex", outer_checksum = "E4AFBA39A5FAA2E77291836C9683ADE882E65A06AB28CA7D61AE7A3AD61EBBD5" },
 ]
 
 [requirements]
+envoy = { version = ">= 1.1.0 and < 2.0.0" }
+gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
+gleam_otp = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
+gleam_time = { version = ">= 1.0.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
+pog = { version = ">= 4.0.0 and < 5.0.0" }

--- a/src/kairos/job.gleam
+++ b/src/kairos/job.gleam
@@ -3,6 +3,8 @@
 //// This module defines the public types used to describe job state and
 //// enqueue configuration.
 
+import gleam/time/timestamp
+
 pub type JobState {
   Pending
   Scheduled
@@ -15,6 +17,7 @@ pub type JobState {
 
 pub type Schedule {
   Immediately
+  At(timestamp.Timestamp)
 }
 
 pub opaque type EnqueueOptions {
@@ -53,4 +56,29 @@ pub fn priority(options: EnqueueOptions) -> Int {
 pub fn schedule(options: EnqueueOptions) -> Schedule {
   let EnqueueOptions(schedule:, ..) = options
   schedule
+}
+
+pub fn state_name(state: JobState) -> String {
+  case state {
+    Pending -> "pending"
+    Scheduled -> "scheduled"
+    Executing -> "executing"
+    Retryable -> "retryable"
+    Completed -> "completed"
+    Discarded -> "discarded"
+    Cancelled -> "cancelled"
+  }
+}
+
+pub fn state_from_string(state: String) -> Result(JobState, Nil) {
+  case state {
+    "pending" -> Ok(Pending)
+    "scheduled" -> Ok(Scheduled)
+    "executing" -> Ok(Executing)
+    "retryable" -> Ok(Retryable)
+    "completed" -> Ok(Completed)
+    "discarded" -> Ok(Discarded)
+    "cancelled" -> Ok(Cancelled)
+    _ -> Error(Nil)
+  }
 }

--- a/src/kairos/postgres/jobs.gleam
+++ b/src/kairos/postgres/jobs.gleam
@@ -1,0 +1,467 @@
+//// PostgreSQL persistence primitives for Kairos jobs.
+
+import gleam/dynamic/decode
+import gleam/option.{type Option, None, Some}
+import gleam/time/timestamp
+import kairos/job
+import kairos/postgres/schema
+import pog as db
+
+pub type JobInsert {
+  JobInsert(
+    worker_name: String,
+    payload: String,
+    state: job.JobState,
+    queue_name: String,
+    priority: Int,
+    attempt: Int,
+    max_attempts: Int,
+    unique_key: Option(String),
+    errors: List(String),
+    scheduled_at: timestamp.Timestamp,
+    attempted_at: Option(timestamp.Timestamp),
+    completed_at: Option(timestamp.Timestamp),
+    discarded_at: Option(timestamp.Timestamp),
+    cancelled_at: Option(timestamp.Timestamp),
+  )
+}
+
+pub type PersistedJob {
+  PersistedJob(
+    id: String,
+    worker_name: String,
+    payload: String,
+    state: job.JobState,
+    queue_name: String,
+    priority: Int,
+    attempt: Int,
+    max_attempts: Int,
+    unique_key: Option(String),
+    errors: List(String),
+    scheduled_at: timestamp.Timestamp,
+    attempted_at: Option(timestamp.Timestamp),
+    completed_at: Option(timestamp.Timestamp),
+    discarded_at: Option(timestamp.Timestamp),
+    cancelled_at: Option(timestamp.Timestamp),
+    inserted_at: timestamp.Timestamp,
+    updated_at: timestamp.Timestamp,
+  )
+}
+
+pub type StoreError {
+  InvalidJobState(String)
+  QueryFailed(db.QueryError)
+  UnexpectedRowCount(expected: Int, actual: Int)
+}
+
+pub fn is_active_unique_key_conflict(error: StoreError) -> Bool {
+  case error {
+    QueryFailed(db.ConstraintViolated(_, constraint, _)) ->
+      constraint == schema.active_unique_key_constraint
+    _ -> False
+  }
+}
+
+type RawPersistedJob {
+  RawPersistedJob(
+    id: String,
+    worker_name: String,
+    payload: String,
+    state: String,
+    queue_name: String,
+    priority: Int,
+    attempt: Int,
+    max_attempts: Int,
+    unique_key: Option(String),
+    errors: List(String),
+    scheduled_at_microseconds: Int,
+    attempted_at_microseconds: Option(Int),
+    completed_at_microseconds: Option(Int),
+    discarded_at_microseconds: Option(Int),
+    cancelled_at_microseconds: Option(Int),
+    inserted_at_microseconds: Int,
+    updated_at_microseconds: Int,
+  )
+}
+
+pub fn insert(
+  connection: db.Connection,
+  new_job: JobInsert,
+) -> Result(PersistedJob, StoreError) {
+  let JobInsert(
+    worker_name: worker_name,
+    payload: payload,
+    state: state,
+    queue_name: queue_name,
+    priority: priority,
+    attempt: attempt,
+    max_attempts: max_attempts,
+    unique_key: unique_key,
+    errors: errors,
+    scheduled_at: scheduled_at,
+    attempted_at: attempted_at,
+    completed_at: completed_at,
+    discarded_at: discarded_at,
+    cancelled_at: cancelled_at,
+  ) = new_job
+
+  "
+  INSERT INTO kairos_jobs (
+    worker_name,
+    payload,
+    state,
+    queue_name,
+    priority,
+    attempt,
+    max_attempts,
+    unique_key,
+    errors,
+    scheduled_at,
+    attempted_at,
+    completed_at,
+    discarded_at,
+    cancelled_at
+  )
+  VALUES (
+    $1::TEXT,
+    $2::TEXT,
+    $3::TEXT,
+    $4::TEXT,
+    $5::INTEGER,
+    $6::INTEGER,
+    $7::INTEGER,
+    $8::TEXT,
+    $9::TEXT[],
+    $10::TIMESTAMPTZ,
+    $11::TIMESTAMPTZ,
+    $12::TIMESTAMPTZ,
+    $13::TIMESTAMPTZ,
+    $14::TIMESTAMPTZ
+  )
+  RETURNING
+    id::TEXT,
+    worker_name,
+    payload,
+    state,
+    queue_name,
+    priority,
+    attempt,
+    max_attempts,
+    unique_key,
+    errors,
+    (EXTRACT(EPOCH FROM scheduled_at) * 1000000)::BIGINT,
+    CASE
+      WHEN attempted_at IS NULL THEN NULL
+      ELSE (EXTRACT(EPOCH FROM attempted_at) * 1000000)::BIGINT
+    END,
+    CASE
+      WHEN completed_at IS NULL THEN NULL
+      ELSE (EXTRACT(EPOCH FROM completed_at) * 1000000)::BIGINT
+    END,
+    CASE
+      WHEN discarded_at IS NULL THEN NULL
+      ELSE (EXTRACT(EPOCH FROM discarded_at) * 1000000)::BIGINT
+    END,
+    CASE
+      WHEN cancelled_at IS NULL THEN NULL
+      ELSE (EXTRACT(EPOCH FROM cancelled_at) * 1000000)::BIGINT
+    END,
+    (EXTRACT(EPOCH FROM inserted_at) * 1000000)::BIGINT,
+    (EXTRACT(EPOCH FROM updated_at) * 1000000)::BIGINT
+  "
+  |> db.query
+  |> db.parameter(db.text(worker_name))
+  |> db.parameter(db.text(payload))
+  |> db.parameter(db.text(job.state_name(state)))
+  |> db.parameter(db.text(queue_name))
+  |> db.parameter(db.int(priority))
+  |> db.parameter(db.int(attempt))
+  |> db.parameter(db.int(max_attempts))
+  |> db.parameter(db.nullable(db.text, unique_key))
+  |> db.parameter(db.array(db.text, errors))
+  |> db.parameter(db.timestamp(scheduled_at))
+  |> db.parameter(db.nullable(db.timestamp, attempted_at))
+  |> db.parameter(db.nullable(db.timestamp, completed_at))
+  |> db.parameter(db.nullable(db.timestamp, discarded_at))
+  |> db.parameter(db.nullable(db.timestamp, cancelled_at))
+  |> db.returning(raw_job_decoder())
+  |> db.execute(connection)
+  |> map_single_row_result
+}
+
+pub fn fetch(
+  connection: db.Connection,
+  id: String,
+) -> Result(Option(PersistedJob), StoreError) {
+  "
+  SELECT
+    id::TEXT,
+    worker_name,
+    payload,
+    state,
+    queue_name,
+    priority,
+    attempt,
+    max_attempts,
+    unique_key,
+    errors,
+    (EXTRACT(EPOCH FROM scheduled_at) * 1000000)::BIGINT,
+    CASE
+      WHEN attempted_at IS NULL THEN NULL
+      ELSE (EXTRACT(EPOCH FROM attempted_at) * 1000000)::BIGINT
+    END,
+    CASE
+      WHEN completed_at IS NULL THEN NULL
+      ELSE (EXTRACT(EPOCH FROM completed_at) * 1000000)::BIGINT
+    END,
+    CASE
+      WHEN discarded_at IS NULL THEN NULL
+      ELSE (EXTRACT(EPOCH FROM discarded_at) * 1000000)::BIGINT
+    END,
+    CASE
+      WHEN cancelled_at IS NULL THEN NULL
+      ELSE (EXTRACT(EPOCH FROM cancelled_at) * 1000000)::BIGINT
+    END,
+    (EXTRACT(EPOCH FROM inserted_at) * 1000000)::BIGINT,
+    (EXTRACT(EPOCH FROM updated_at) * 1000000)::BIGINT
+  FROM kairos_jobs
+  WHERE id = $1
+  "
+  |> db.query
+  |> db.parameter(db.text(id))
+  |> db.returning(raw_job_decoder())
+  |> db.execute(connection)
+  |> map_optional_row_result
+}
+
+pub fn fetch_available(
+  connection: db.Connection,
+  now: timestamp.Timestamp,
+  limit: Int,
+) -> Result(List(PersistedJob), StoreError) {
+  "
+  SELECT
+    id::TEXT,
+    worker_name,
+    payload,
+    state,
+    queue_name,
+    priority,
+    attempt,
+    max_attempts,
+    unique_key,
+    errors,
+    (EXTRACT(EPOCH FROM scheduled_at) * 1000000)::BIGINT,
+    CASE
+      WHEN attempted_at IS NULL THEN NULL
+      ELSE (EXTRACT(EPOCH FROM attempted_at) * 1000000)::BIGINT
+    END,
+    CASE
+      WHEN completed_at IS NULL THEN NULL
+      ELSE (EXTRACT(EPOCH FROM completed_at) * 1000000)::BIGINT
+    END,
+    CASE
+      WHEN discarded_at IS NULL THEN NULL
+      ELSE (EXTRACT(EPOCH FROM discarded_at) * 1000000)::BIGINT
+    END,
+    CASE
+      WHEN cancelled_at IS NULL THEN NULL
+      ELSE (EXTRACT(EPOCH FROM cancelled_at) * 1000000)::BIGINT
+    END,
+    (EXTRACT(EPOCH FROM inserted_at) * 1000000)::BIGINT,
+    (EXTRACT(EPOCH FROM updated_at) * 1000000)::BIGINT
+  FROM kairos_jobs
+  WHERE state IN ('pending', 'scheduled', 'retryable')
+    AND scheduled_at <= $1
+  ORDER BY priority DESC, scheduled_at ASC, inserted_at ASC
+  LIMIT $2
+  "
+  |> db.query
+  |> db.parameter(db.timestamp(now))
+  |> db.parameter(db.int(limit))
+  |> db.returning(raw_job_decoder())
+  |> db.execute(connection)
+  |> map_many_row_result
+}
+
+fn raw_job_decoder() -> decode.Decoder(RawPersistedJob) {
+  {
+    use id <- decode.field(0, decode.string)
+    use worker_name <- decode.field(1, decode.string)
+    use payload <- decode.field(2, decode.string)
+    use state <- decode.field(3, decode.string)
+    use queue_name <- decode.field(4, decode.string)
+    use priority <- decode.field(5, decode.int)
+    use attempt <- decode.field(6, decode.int)
+    use max_attempts <- decode.field(7, decode.int)
+    use unique_key <- decode.field(8, decode.optional(decode.string))
+    use errors <- decode.field(9, decode.list(decode.string))
+    use scheduled_at_microseconds <- decode.field(10, decode.int)
+    use attempted_at_microseconds <- decode.field(
+      11,
+      decode.optional(decode.int),
+    )
+    use completed_at_microseconds <- decode.field(
+      12,
+      decode.optional(decode.int),
+    )
+    use discarded_at_microseconds <- decode.field(
+      13,
+      decode.optional(decode.int),
+    )
+    use cancelled_at_microseconds <- decode.field(
+      14,
+      decode.optional(decode.int),
+    )
+    use inserted_at_microseconds <- decode.field(15, decode.int)
+    use updated_at_microseconds <- decode.field(16, decode.int)
+
+    decode.success(RawPersistedJob(
+      id: id,
+      worker_name: worker_name,
+      payload: payload,
+      state: state,
+      queue_name: queue_name,
+      priority: priority,
+      attempt: attempt,
+      max_attempts: max_attempts,
+      unique_key: unique_key,
+      errors: errors,
+      scheduled_at_microseconds: scheduled_at_microseconds,
+      attempted_at_microseconds: attempted_at_microseconds,
+      completed_at_microseconds: completed_at_microseconds,
+      discarded_at_microseconds: discarded_at_microseconds,
+      cancelled_at_microseconds: cancelled_at_microseconds,
+      inserted_at_microseconds: inserted_at_microseconds,
+      updated_at_microseconds: updated_at_microseconds,
+    ))
+  }
+}
+
+fn map_single_row_result(
+  result: Result(db.Returned(RawPersistedJob), db.QueryError),
+) -> Result(PersistedJob, StoreError) {
+  case result {
+    Error(error) -> Error(QueryFailed(error))
+    Ok(db.Returned(count:, rows:)) ->
+      case rows {
+        [row] -> to_persisted_job(row)
+        _ -> Error(UnexpectedRowCount(expected: 1, actual: count))
+      }
+  }
+}
+
+fn map_optional_row_result(
+  result: Result(db.Returned(RawPersistedJob), db.QueryError),
+) -> Result(Option(PersistedJob), StoreError) {
+  case result {
+    Error(error) -> Error(QueryFailed(error))
+    Ok(db.Returned(count:, rows:)) ->
+      case rows {
+        [] -> Ok(None)
+        [row] -> to_persisted_job(row) |> map_ok_option
+        _ -> Error(UnexpectedRowCount(expected: 1, actual: count))
+      }
+  }
+}
+
+fn map_many_row_result(
+  result: Result(db.Returned(RawPersistedJob), db.QueryError),
+) -> Result(List(PersistedJob), StoreError) {
+  case result {
+    Error(error) -> Error(QueryFailed(error))
+    Ok(db.Returned(rows:, ..)) -> collect_jobs(rows)
+  }
+}
+
+fn collect_jobs(
+  rows: List(RawPersistedJob),
+) -> Result(List(PersistedJob), StoreError) {
+  case rows {
+    [] -> Ok([])
+    [row, ..rest] ->
+      case to_persisted_job(row), collect_jobs(rest) {
+        Ok(job), Ok(other_jobs) -> Ok([job, ..other_jobs])
+        Error(error), _ -> Error(error)
+        _, Error(error) -> Error(error)
+      }
+  }
+}
+
+fn map_ok_option(
+  result: Result(PersistedJob, StoreError),
+) -> Result(Option(PersistedJob), StoreError) {
+  case result {
+    Ok(job) -> Ok(Some(job))
+    Error(error) -> Error(error)
+  }
+}
+
+fn to_persisted_job(raw: RawPersistedJob) -> Result(PersistedJob, StoreError) {
+  let RawPersistedJob(
+    id: id,
+    worker_name: worker_name,
+    payload: payload,
+    state: raw_state,
+    queue_name: queue_name,
+    priority: priority,
+    attempt: attempt,
+    max_attempts: max_attempts,
+    unique_key: unique_key,
+    errors: errors,
+    scheduled_at_microseconds: scheduled_at_microseconds,
+    attempted_at_microseconds: attempted_at_microseconds,
+    completed_at_microseconds: completed_at_microseconds,
+    discarded_at_microseconds: discarded_at_microseconds,
+    cancelled_at_microseconds: cancelled_at_microseconds,
+    inserted_at_microseconds: inserted_at_microseconds,
+    updated_at_microseconds: updated_at_microseconds,
+  ) = raw
+
+  case job.state_from_string(raw_state) {
+    Ok(state) ->
+      Ok(PersistedJob(
+        id: id,
+        worker_name: worker_name,
+        payload: payload,
+        state: state,
+        queue_name: queue_name,
+        priority: priority,
+        attempt: attempt,
+        max_attempts: max_attempts,
+        unique_key: unique_key,
+        errors: errors,
+        scheduled_at: microseconds_to_timestamp(scheduled_at_microseconds),
+        attempted_at: option_microseconds_to_timestamp(
+          attempted_at_microseconds,
+        ),
+        completed_at: option_microseconds_to_timestamp(
+          completed_at_microseconds,
+        ),
+        discarded_at: option_microseconds_to_timestamp(
+          discarded_at_microseconds,
+        ),
+        cancelled_at: option_microseconds_to_timestamp(
+          cancelled_at_microseconds,
+        ),
+        inserted_at: microseconds_to_timestamp(inserted_at_microseconds),
+        updated_at: microseconds_to_timestamp(updated_at_microseconds),
+      ))
+    Error(_) -> Error(InvalidJobState(raw_state))
+  }
+}
+
+fn microseconds_to_timestamp(microseconds: Int) -> timestamp.Timestamp {
+  let seconds = microseconds / 1_000_000
+  let nanoseconds = { microseconds % 1_000_000 } * 1000
+  timestamp.from_unix_seconds_and_nanoseconds(seconds, nanoseconds)
+}
+
+fn option_microseconds_to_timestamp(
+  microseconds: Option(Int),
+) -> Option(timestamp.Timestamp) {
+  case microseconds {
+    Some(value) -> Some(microseconds_to_timestamp(value))
+    None -> None
+  }
+}

--- a/src/kairos/postgres/schema.gleam
+++ b/src/kairos/postgres/schema.gleam
@@ -1,0 +1,110 @@
+//// PostgreSQL schema definitions for Kairos persistence.
+
+import gleam/list
+import gleam/string
+import kairos/job
+
+pub const jobs_table = "kairos_jobs"
+
+pub const active_unique_key_constraint = "kairos_jobs_unique_key_active_idx"
+
+pub type Migration {
+  Migration(version: Int, name: String, statements: List(String))
+}
+
+pub fn migrations() -> List(Migration) {
+  [initial_migration()]
+}
+
+pub fn initial_migration() -> Migration {
+  Migration(version: 1, name: "create_jobs_table", statements: [
+    "CREATE EXTENSION IF NOT EXISTS pgcrypto",
+    create_jobs_table_statement(),
+    create_unique_key_index_statement(),
+    create_updated_at_function_statement(),
+    create_updated_at_trigger_statement(),
+  ])
+}
+
+fn supported_states() -> List(String) {
+  [
+    job.Pending,
+    job.Scheduled,
+    job.Executing,
+    job.Retryable,
+    job.Completed,
+    job.Discarded,
+    job.Cancelled,
+  ]
+  |> list.map(job.state_name)
+}
+
+fn active_unique_states() -> List(String) {
+  [job.Pending, job.Scheduled, job.Executing, job.Retryable]
+  |> list.map(job.state_name)
+}
+
+fn create_jobs_table_statement() -> String {
+  "CREATE TABLE " <> jobs_table <> " (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    worker_name TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (state IN (" <> quoted_csv(supported_states()) <> ")),
+    queue_name TEXT NOT NULL,
+    priority INTEGER NOT NULL DEFAULT 0,
+    attempt INTEGER NOT NULL DEFAULT 0 CHECK (attempt >= 0),
+    max_attempts INTEGER NOT NULL CHECK (max_attempts > 0),
+    unique_key TEXT,
+    errors TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    scheduled_at TIMESTAMPTZ NOT NULL,
+    attempted_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    discarded_at TIMESTAMPTZ,
+    cancelled_at TIMESTAMPTZ,
+    inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT kairos_jobs_attempt_bounds_check CHECK (attempt <= max_attempts),
+    CONSTRAINT kairos_jobs_completed_state_check CHECK (
+      (state = 'completed' AND completed_at IS NOT NULL AND discarded_at IS NULL AND cancelled_at IS NULL)
+      OR (state <> 'completed' AND completed_at IS NULL)
+    ),
+    CONSTRAINT kairos_jobs_discarded_state_check CHECK (
+      (state = 'discarded' AND discarded_at IS NOT NULL AND completed_at IS NULL AND cancelled_at IS NULL)
+      OR (state <> 'discarded' AND discarded_at IS NULL)
+    ),
+    CONSTRAINT kairos_jobs_cancelled_state_check CHECK (
+      (state = 'cancelled' AND cancelled_at IS NOT NULL AND completed_at IS NULL AND discarded_at IS NULL)
+      OR (state <> 'cancelled' AND cancelled_at IS NULL)
+    )
+  )"
+}
+
+fn create_unique_key_index_statement() -> String {
+  "CREATE UNIQUE INDEX " <> active_unique_key_constraint <> "
+  ON " <> jobs_table <> " (unique_key)
+  WHERE unique_key IS NOT NULL
+    AND state IN (" <> quoted_csv(active_unique_states()) <> ")"
+}
+
+fn create_updated_at_function_statement() -> String {
+  "CREATE OR REPLACE FUNCTION kairos_touch_updated_at()
+  RETURNS TRIGGER AS $$
+  BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+  END;
+  $$ LANGUAGE plpgsql"
+}
+
+fn create_updated_at_trigger_statement() -> String {
+  "CREATE TRIGGER kairos_jobs_set_updated_at
+  BEFORE UPDATE ON " <> jobs_table <> "
+  FOR EACH ROW
+  EXECUTE FUNCTION kairos_touch_updated_at()"
+}
+
+fn quoted_csv(values: List(String)) -> String {
+  values
+  |> list.map(fn(value) { "'" <> value <> "'" })
+  |> string.join(", ")
+}

--- a/test/kairos_job_test.gleam
+++ b/test/kairos_job_test.gleam
@@ -14,24 +14,20 @@ pub fn default_enqueue_options_test() {
   assert job.schedule(options) == job.Immediately
 }
 
-pub fn job_state_variants_test() {
-  assert state_name(job.Pending) == "pending"
-  assert state_name(job.Scheduled) == "scheduled"
-  assert state_name(job.Executing) == "executing"
-  assert state_name(job.Retryable) == "retryable"
-  assert state_name(job.Completed) == "completed"
-  assert state_name(job.Discarded) == "discarded"
-  assert state_name(job.Cancelled) == "cancelled"
-}
-
-fn state_name(state: job.JobState) -> String {
-  case state {
-    job.Pending -> "pending"
-    job.Scheduled -> "scheduled"
-    job.Executing -> "executing"
-    job.Retryable -> "retryable"
-    job.Completed -> "completed"
-    job.Discarded -> "discarded"
-    job.Cancelled -> "cancelled"
-  }
+pub fn job_state_round_trip_test() {
+  assert job.state_name(job.Pending) == "pending"
+  assert job.state_name(job.Scheduled) == "scheduled"
+  assert job.state_name(job.Executing) == "executing"
+  assert job.state_name(job.Retryable) == "retryable"
+  assert job.state_name(job.Completed) == "completed"
+  assert job.state_name(job.Discarded) == "discarded"
+  assert job.state_name(job.Cancelled) == "cancelled"
+  assert job.state_from_string("pending") == Ok(job.Pending)
+  assert job.state_from_string("scheduled") == Ok(job.Scheduled)
+  assert job.state_from_string("executing") == Ok(job.Executing)
+  assert job.state_from_string("retryable") == Ok(job.Retryable)
+  assert job.state_from_string("completed") == Ok(job.Completed)
+  assert job.state_from_string("discarded") == Ok(job.Discarded)
+  assert job.state_from_string("cancelled") == Ok(job.Cancelled)
+  assert job.state_from_string("unknown") == Error(Nil)
 }

--- a/test/kairos_postgres_integration_test.gleam
+++ b/test/kairos_postgres_integration_test.gleam
@@ -1,0 +1,398 @@
+import envoy
+import gleam/erlang/process
+import gleam/list
+import gleam/option.{None, Some}
+import gleam/otp/actor
+import gleam/time/duration
+import gleam/time/timestamp
+import gleeunit
+import kairos/job
+import kairos/postgres/jobs
+import kairos/postgres/schema
+import pog
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+pub fn insert_and_fetch_job_test() {
+  with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let insert =
+      jobs.JobInsert(
+        worker_name: "EmailWorker",
+        payload: "{\"user_id\": 10}",
+        state: job.Pending,
+        queue_name: "default",
+        priority: 10,
+        attempt: 0,
+        max_attempts: 5,
+        unique_key: Some("welcome-email:10"),
+        errors: [],
+        scheduled_at: now,
+        attempted_at: None,
+        completed_at: None,
+        discarded_at: None,
+        cancelled_at: None,
+      )
+
+    let assert Ok(inserted) = jobs.insert(connection, insert)
+    let jobs.PersistedJob(
+      id: id,
+      worker_name: worker_name,
+      payload: payload,
+      state: state,
+      queue_name: queue_name,
+      priority: priority,
+      attempt: attempt,
+      max_attempts: max_attempts,
+      unique_key: unique_key,
+      errors: errors,
+      ..,
+    ) = inserted
+
+    assert worker_name == "EmailWorker"
+    assert payload == "{\"user_id\": 10}"
+    assert state == job.Pending
+    assert queue_name == "default"
+    assert priority == 10
+    assert attempt == 0
+    assert max_attempts == 5
+    assert unique_key == Some("welcome-email:10")
+    assert errors == []
+
+    let assert Ok(Some(fetched)) = jobs.fetch(connection, id)
+    let jobs.PersistedJob(id: fetched_id, state: fetched_state, ..) = fetched
+
+    assert fetched_id == id
+    assert fetched_state == job.Pending
+  })
+}
+
+pub fn fetch_available_respects_schedule_and_priority_test() {
+  with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let later = timestamp.add(now, duration.minutes(5))
+
+    let assert Ok(_) =
+      jobs.insert(
+        connection,
+        jobs.JobInsert(
+          worker_name: "ImmediateWorker",
+          payload: "{}",
+          state: job.Pending,
+          queue_name: "default",
+          priority: 1,
+          attempt: 0,
+          max_attempts: 3,
+          unique_key: None,
+          errors: [],
+          scheduled_at: now,
+          attempted_at: None,
+          completed_at: None,
+          discarded_at: None,
+          cancelled_at: None,
+        ),
+      )
+
+    let assert Ok(_) =
+      jobs.insert(
+        connection,
+        jobs.JobInsert(
+          worker_name: "ScheduledWorker",
+          payload: "{}",
+          state: job.Scheduled,
+          queue_name: "default",
+          priority: 5,
+          attempt: 0,
+          max_attempts: 3,
+          unique_key: None,
+          errors: [],
+          scheduled_at: later,
+          attempted_at: None,
+          completed_at: None,
+          discarded_at: None,
+          cancelled_at: None,
+        ),
+      )
+
+    let assert Ok(available_now) = jobs.fetch_available(connection, now, 10)
+    assert list.length(available_now) == 1
+
+    let assert [first] = available_now
+    let jobs.PersistedJob(worker_name: first_name, ..) = first
+    assert first_name == "ImmediateWorker"
+
+    let assert Ok(available_later) =
+      jobs.fetch_available(
+        connection,
+        timestamp.add(later, duration.seconds(1)),
+        10,
+      )
+
+    assert list.length(available_later) == 2
+
+    let assert [scheduled_first, immediate_second] = available_later
+    let jobs.PersistedJob(worker_name: scheduled_name, ..) = scheduled_first
+    let jobs.PersistedJob(worker_name: immediate_name, ..) = immediate_second
+
+    assert scheduled_name == "ScheduledWorker"
+    assert immediate_name == "ImmediateWorker"
+  })
+}
+
+pub fn unique_key_only_blocks_active_jobs_test() {
+  with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let unique_key = Some("daily-report")
+
+    let assert Ok(_) =
+      jobs.insert(
+        connection,
+        jobs.JobInsert(
+          worker_name: "CancelledJobWorker",
+          payload: "{}",
+          state: job.Cancelled,
+          queue_name: "reports",
+          priority: 0,
+          attempt: 0,
+          max_attempts: 1,
+          unique_key: unique_key,
+          errors: [],
+          scheduled_at: now,
+          attempted_at: None,
+          completed_at: None,
+          discarded_at: None,
+          cancelled_at: Some(now),
+        ),
+      )
+
+    let assert Ok(_) =
+      jobs.insert(
+        connection,
+        jobs.JobInsert(
+          worker_name: "ActiveJobWorker",
+          payload: "{}",
+          state: job.Pending,
+          queue_name: "reports",
+          priority: 0,
+          attempt: 0,
+          max_attempts: 1,
+          unique_key: unique_key,
+          errors: [],
+          scheduled_at: now,
+          attempted_at: None,
+          completed_at: None,
+          discarded_at: None,
+          cancelled_at: None,
+        ),
+      )
+
+    let duplicate_result =
+      jobs.insert(
+        connection,
+        jobs.JobInsert(
+          worker_name: "DuplicateActiveJobWorker",
+          payload: "{}",
+          state: job.Pending,
+          queue_name: "reports",
+          priority: 0,
+          attempt: 0,
+          max_attempts: 1,
+          unique_key: unique_key,
+          errors: [],
+          scheduled_at: now,
+          attempted_at: None,
+          completed_at: None,
+          discarded_at: None,
+          cancelled_at: None,
+        ),
+      )
+
+    case duplicate_result {
+      Error(error) -> {
+        assert jobs.is_active_unique_key_conflict(error)
+      }
+      _ -> panic as "expected unique key violation"
+    }
+  })
+}
+
+pub fn retryable_and_terminal_state_round_trip_test() {
+  with_database(fn(connection) {
+    let now = timestamp.system_time()
+
+    let assert Ok(retryable) =
+      jobs.insert(
+        connection,
+        jobs.JobInsert(
+          worker_name: "RetryableWorker",
+          payload: "{}",
+          state: job.Retryable,
+          queue_name: "default",
+          priority: 2,
+          attempt: 2,
+          max_attempts: 5,
+          unique_key: None,
+          errors: ["timeout", "database busy"],
+          scheduled_at: now,
+          attempted_at: Some(now),
+          completed_at: None,
+          discarded_at: None,
+          cancelled_at: None,
+        ),
+      )
+
+    let jobs.PersistedJob(id: retryable_id, errors: retryable_errors, ..) =
+      retryable
+    assert retryable_errors == ["timeout", "database busy"]
+
+    let assert Ok(available) = jobs.fetch_available(connection, now, 10)
+    let retryable_names =
+      available
+      |> list.map(fn(job) {
+        let jobs.PersistedJob(worker_name: worker_name, ..) = job
+        worker_name
+      })
+
+    assert list.contains(retryable_names, "RetryableWorker")
+
+    let assert Ok(completed) =
+      jobs.insert(
+        connection,
+        jobs.JobInsert(
+          worker_name: "CompletedWorker",
+          payload: "{}",
+          state: job.Completed,
+          queue_name: "default",
+          priority: 0,
+          attempt: 1,
+          max_attempts: 1,
+          unique_key: None,
+          errors: [],
+          scheduled_at: now,
+          attempted_at: Some(now),
+          completed_at: Some(now),
+          discarded_at: None,
+          cancelled_at: None,
+        ),
+      )
+
+    let assert Ok(discarded) =
+      jobs.insert(
+        connection,
+        jobs.JobInsert(
+          worker_name: "DiscardedWorker",
+          payload: "{}",
+          state: job.Discarded,
+          queue_name: "default",
+          priority: 0,
+          attempt: 5,
+          max_attempts: 5,
+          unique_key: None,
+          errors: ["poison payload"],
+          scheduled_at: now,
+          attempted_at: Some(now),
+          completed_at: None,
+          discarded_at: Some(now),
+          cancelled_at: None,
+        ),
+      )
+
+    let jobs.PersistedJob(id: completed_id, completed_at: completed_at, ..) =
+      completed
+    let jobs.PersistedJob(
+      id: discarded_id,
+      discarded_at: discarded_at,
+      errors: discarded_errors,
+      ..,
+    ) = discarded
+
+    let expected_now = to_postgres_precision(now)
+
+    assert completed_at == Some(expected_now)
+    assert discarded_at == Some(expected_now)
+    assert discarded_errors == ["poison payload"]
+
+    let assert Ok(Some(fetched_retryable)) =
+      jobs.fetch(connection, retryable_id)
+    let assert Ok(Some(fetched_completed)) =
+      jobs.fetch(connection, completed_id)
+    let assert Ok(Some(fetched_discarded)) =
+      jobs.fetch(connection, discarded_id)
+
+    let jobs.PersistedJob(state: retryable_state, ..) = fetched_retryable
+    let jobs.PersistedJob(state: completed_state, ..) = fetched_completed
+    let jobs.PersistedJob(state: discarded_state, ..) = fetched_discarded
+
+    assert retryable_state == job.Retryable
+    assert completed_state == job.Completed
+    assert discarded_state == job.Discarded
+  })
+}
+
+fn with_database(run: fn(pog.Connection) -> Nil) -> Nil {
+  let name = process.new_name("kairos_postgres_test")
+  let assert Ok(database_url) = envoy.get("KAIROS_TEST_DATABASE_URL")
+    as "Set KAIROS_TEST_DATABASE_URL to a dedicated PostgreSQL test database before running integration tests."
+
+  let assert Ok(config) = pog.url_config(name, database_url)
+  let assert Ok(actor.Started(pid: pid, data: connection)) = pog.start(config)
+
+  wait_for_connection(connection, 20)
+  reset_schema(connection)
+  run(connection)
+  process.send_exit(pid)
+}
+
+fn wait_for_connection(connection: pog.Connection, remaining: Int) -> Nil {
+  case pog.query("SELECT 1") |> pog.execute(connection) {
+    Ok(_) -> Nil
+    Error(_) ->
+      case remaining {
+        0 -> {
+          let assert Ok(_) = pog.query("SELECT 1") |> pog.execute(connection)
+          Nil
+        }
+        _ -> {
+          process.sleep(50)
+          wait_for_connection(connection, remaining - 1)
+        }
+      }
+  }
+}
+
+fn reset_schema(connection: pog.Connection) -> Nil {
+  [
+    "DROP TRIGGER IF EXISTS kairos_jobs_set_updated_at ON kairos_jobs",
+    "DROP FUNCTION IF EXISTS kairos_touch_updated_at()",
+    "DROP TABLE IF EXISTS kairos_jobs",
+  ]
+  |> execute_statements(connection)
+
+  let schema.Migration(statements:, ..) = schema.initial_migration()
+  execute_statements(statements, connection)
+}
+
+fn execute_statements(
+  statements: List(String),
+  connection: pog.Connection,
+) -> Nil {
+  case statements {
+    [] -> Nil
+    [statement, ..rest] -> {
+      let assert Ok(_) = pog.query(statement) |> pog.execute(connection)
+      execute_statements(rest, connection)
+    }
+  }
+}
+
+fn to_postgres_precision(timestamp: timestamp.Timestamp) -> timestamp.Timestamp {
+  let #(seconds, nanoseconds) =
+    timestamp.to_unix_seconds_and_nanoseconds(timestamp)
+
+  timestamp.from_unix_seconds_and_nanoseconds(
+    seconds,
+    { nanoseconds / 1000 } * 1000,
+  )
+}


### PR DESCRIPTION
## Summary
- add Kairos PostgreSQL schema definitions and persistence primitives for insert, fetch, and available-job queries
- extend the core job domain with durable state string mapping and scheduled execution timestamps
- add PostgreSQL integration coverage around scheduling, retries, terminal states, and active unique-key conflicts
- document host-app PostgreSQL ownership, dedicated test database setup, and migration expectations

## Why
Issue #3 requires the first durable storage layer for Kairos. This PR establishes the jobs table shape, migration strategy, and repository API needed to enqueue and fetch jobs safely from PostgreSQL.

## Developer impact
Host applications continue to own environment loading, `pog` pool supervision, and migration execution. Kairos now provides the schema and persistence modules they can call into, and the test suite now requires an explicit `KAIROS_TEST_DATABASE_URL` that points at a dedicated test database.

Closes #3.

## Validation
- `KAIROS_TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/kairos_test?sslmode=disable gleam test`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/kairos_test?sslmode=disable gleam run` in `/tmp/kairos_sample_app`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for scheduling jobs to execute at specific timestamps.
  * Introduced PostgreSQL persistence layer with job storage, retrieval, and availability-based filtering with priority ordering.

* **Documentation**
  * Expanded setup guide with integration requirements, database configuration, migration examples for existing applications, and development environment setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->