### PR TITLE
Add transactional enqueue API

### DIFF
--- a/src/kairos.gleam
+++ b/src/kairos.gleam
@@ -1,7 +1,21 @@
+import gleam/list
+import gleam/option.{None}
 import gleam/otp/actor
 import gleam/otp/supervision.{type ChildSpecification}
+import gleam/time/timestamp
 import kairos/config
+import kairos/job
+import kairos/postgres/job_store
+import kairos/queue
 import kairos/supervision as kairos_supervision
+import kairos/worker
+
+pub type EnqueueError {
+  QueueNotConfigured(String)
+  StoreQueryFailed
+  UnexpectedStoredRowCount(expected: Int, actual: Int)
+  InvalidStoredState(String)
+}
 
 pub fn package_name() -> String {
   "kairos"
@@ -17,4 +31,133 @@ pub fn supervised(
   config: config.Config,
 ) -> ChildSpecification(kairos_supervision.Runtime) {
   kairos_supervision.supervised(config: config)
+}
+
+pub fn enqueue(
+  config: config.Config,
+  contract: worker.Worker(args),
+  args: args,
+) -> Result(job.EnqueuedJob(args), EnqueueError) {
+  enqueue_with(config, contract, args, worker.default_options(contract))
+}
+
+pub fn enqueue_with(
+  config: config.Config,
+  contract: worker.Worker(args),
+  args: args,
+  options: job.EnqueueOptions,
+) -> Result(job.EnqueuedJob(args), EnqueueError) {
+  let queue_name = job.queue(options)
+  case validate_queue(config, queue_name) {
+    Error(error) -> Error(error)
+    Ok(Nil) -> {
+      let scheduled_at = schedule_at(options)
+      let state = state_for_schedule(options)
+      let new_job =
+        job_store.JobInsert(
+          worker_name: worker.name(contract),
+          payload: worker.encode(contract, args),
+          state: state,
+          queue_name: queue_name,
+          priority: job.priority(options),
+          attempt: 0,
+          max_attempts: job.max_attempts(options),
+          unique_key: None,
+          errors: [],
+          scheduled_at: scheduled_at,
+          attempted_at: None,
+          completed_at: None,
+          discarded_at: None,
+          cancelled_at: None,
+        )
+
+      case job_store.insert(config.connection(config), new_job) {
+        Ok(persisted) -> Ok(to_enqueued_job(persisted, args))
+        Error(error) -> Error(map_store_error(error))
+      }
+    }
+  }
+}
+
+fn validate_queue(
+  config: config.Config,
+  queue_name: String,
+) -> Result(Nil, EnqueueError) {
+  case
+    config.queues(config)
+    |> list.any(fn(queue_definition) {
+      queue.name(queue_definition) == queue_name
+    })
+  {
+    True -> Ok(Nil)
+    False -> Error(QueueNotConfigured(queue_name))
+  }
+}
+
+fn schedule_at(options: job.EnqueueOptions) -> timestamp.Timestamp {
+  case job.schedule(options) {
+    job.Immediately -> timestamp.system_time()
+    job.At(scheduled_at) -> scheduled_at
+  }
+}
+
+fn state_for_schedule(options: job.EnqueueOptions) -> job.JobState {
+  case job.schedule(options) {
+    job.Immediately -> job.Pending
+    job.At(_) -> job.Scheduled
+  }
+}
+
+fn to_enqueued_job(
+  persisted: job_store.PersistedJob,
+  args: args,
+) -> job.EnqueuedJob(args) {
+  let job_store.PersistedJob(
+    id: id,
+    worker_name: worker_name,
+    state: state,
+    queue_name: queue_name,
+    priority: priority,
+    attempt: attempt,
+    max_attempts: max_attempts,
+    unique_key: unique_key,
+    errors: errors,
+    scheduled_at: scheduled_at,
+    attempted_at: attempted_at,
+    completed_at: completed_at,
+    discarded_at: discarded_at,
+    cancelled_at: cancelled_at,
+    inserted_at: inserted_at,
+    updated_at: updated_at,
+    ..,
+  ) = persisted
+
+  job.EnqueuedJob(
+    id: id,
+    worker_name: worker_name,
+    args: args,
+    state: state,
+    queue_name: queue_name,
+    priority: priority,
+    attempt: attempt,
+    max_attempts: max_attempts,
+    unique_key: unique_key,
+    errors: errors,
+    scheduled_at: scheduled_at,
+    attempted_at: attempted_at,
+    completed_at: completed_at,
+    discarded_at: discarded_at,
+    cancelled_at: cancelled_at,
+    inserted_at: inserted_at,
+    updated_at: updated_at,
+  )
+}
+
+fn map_store_error(error: job_store.StoreError) -> EnqueueError {
+  case error {
+    job_store.QueryFailed(_) -> StoreQueryFailed
+    job_store.UnexpectedRowCount(expected:, actual:) ->
+      UnexpectedStoredRowCount(expected: expected, actual: actual)
+    job_store.InvalidJobState(state) -> InvalidStoredState(state)
+  }
 }

--- a/src/kairos.gleam
+++ b/src/kairos.gleam
@@ -51,8 +51,7 @@ pub fn enqueue_with(
   case validate_queue(config, queue_name) {
     Error(error) -> Error(error)
     Ok(Nil) -> {
-      let scheduled_at = schedule_at(options)
-      let state = state_for_schedule(options)
+      let #(scheduled_at, state) = schedule_context(options)
       let new_job =
         job_store.JobInsert(
           worker_name: worker.name(contract),
@@ -94,17 +93,12 @@ fn validate_queue(
   }
 }
 
-fn schedule_at(options: job.EnqueueOptions) -> timestamp.Timestamp {
+fn schedule_context(
+  options: job.EnqueueOptions,
+) -> #(timestamp.Timestamp, job.JobState) {
   case job.schedule(options) {
-    job.Immediately -> timestamp.system_time()
-    job.At(scheduled_at) -> scheduled_at
-  }
-}
-
-fn state_for_schedule(options: job.EnqueueOptions) -> job.JobState {
-  case job.schedule(options) {
-    job.Immediately -> job.Pending
-    job.At(_) -> job.Scheduled
+    job.Immediately -> #(timestamp.system_time(), job.Pending)
+    job.At(scheduled_at) -> #(scheduled_at, job.Scheduled)
   }
 }
 

--- a/src/kairos/job.gleam
+++ b/src/kairos/job.gleam
@@ -3,6 +3,8 @@
 //// This module defines the public types used to describe job state and
 //// enqueue configuration.
 
+import gleam/option.{type Option}
+import gleam/string
 import gleam/time/timestamp
 
 pub type JobState {
@@ -20,12 +22,39 @@ pub type Schedule {
   At(timestamp.Timestamp)
 }
 
+pub type EnqueueOptionError {
+  BlankQueueName
+  NonPositiveMaxAttempts
+}
+
 pub opaque type EnqueueOptions {
   EnqueueOptions(
     queue: String,
     max_attempts: Int,
     priority: Int,
     schedule: Schedule,
+  )
+}
+
+pub type EnqueuedJob(args) {
+  EnqueuedJob(
+    id: String,
+    worker_name: String,
+    args: args,
+    state: JobState,
+    queue_name: String,
+    priority: Int,
+    attempt: Int,
+    max_attempts: Int,
+    unique_key: Option(String),
+    errors: List(String),
+    scheduled_at: timestamp.Timestamp,
+    attempted_at: Option(timestamp.Timestamp),
+    completed_at: Option(timestamp.Timestamp),
+    discarded_at: Option(timestamp.Timestamp),
+    cancelled_at: Option(timestamp.Timestamp),
+    inserted_at: timestamp.Timestamp,
+    updated_at: timestamp.Timestamp,
   )
 }
 
@@ -43,9 +72,47 @@ pub fn queue(options: EnqueueOptions) -> String {
   queue
 }
 
+pub fn with_queue(
+  options: EnqueueOptions,
+  queue: String,
+) -> Result(EnqueueOptions, EnqueueOptionError) {
+  case string.trim(queue) {
+    "" -> Error(BlankQueueName)
+    trimmed_queue -> {
+      let EnqueueOptions(max_attempts:, priority:, schedule:, ..) = options
+
+      Ok(EnqueueOptions(
+        queue: trimmed_queue,
+        max_attempts: max_attempts,
+        priority: priority,
+        schedule: schedule,
+      ))
+    }
+  }
+}
+
 pub fn max_attempts(options: EnqueueOptions) -> Int {
   let EnqueueOptions(max_attempts:, ..) = options
   max_attempts
+}
+
+pub fn with_max_attempts(
+  options: EnqueueOptions,
+  max_attempts: Int,
+) -> Result(EnqueueOptions, EnqueueOptionError) {
+  case max_attempts <= 0 {
+    True -> Error(NonPositiveMaxAttempts)
+    False -> {
+      let EnqueueOptions(queue:, priority:, schedule:, ..) = options
+
+      Ok(EnqueueOptions(
+        queue: queue,
+        max_attempts: max_attempts,
+        priority: priority,
+        schedule: schedule,
+      ))
+    }
+  }
 }
 
 pub fn priority(options: EnqueueOptions) -> Int {
@@ -53,9 +120,34 @@ pub fn priority(options: EnqueueOptions) -> Int {
   priority
 }
 
+pub fn with_priority(options: EnqueueOptions, priority: Int) -> EnqueueOptions {
+  let EnqueueOptions(queue:, max_attempts:, schedule:, ..) = options
+
+  EnqueueOptions(
+    queue: queue,
+    max_attempts: max_attempts,
+    priority: priority,
+    schedule: schedule,
+  )
+}
+
 pub fn schedule(options: EnqueueOptions) -> Schedule {
   let EnqueueOptions(schedule:, ..) = options
   schedule
+}
+
+pub fn with_schedule(
+  options: EnqueueOptions,
+  schedule: Schedule,
+) -> EnqueueOptions {
+  let EnqueueOptions(queue:, max_attempts:, priority:, ..) = options
+
+  EnqueueOptions(
+    queue: queue,
+    max_attempts: max_attempts,
+    priority: priority,
+    schedule: schedule,
+  )
 }
 
 pub fn state_name(state: JobState) -> String {

--- a/test/kairos/enqueue_test.gleam
+++ b/test/kairos/enqueue_test.gleam
@@ -1,0 +1,157 @@
+import gleam/option.{Some}
+import gleam/time/duration
+import gleam/time/timestamp
+import gleeunit
+import kairos
+import kairos/config
+import kairos/job
+import kairos/postgres/job_store
+import kairos/postgres/test_db
+import kairos/queue
+import kairos/worker
+import pog
+
+type MailArgs {
+  MailArgs(recipient: String, template: String)
+}
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+pub fn enqueue_uses_worker_defaults_and_persists_typed_payload_test() {
+  test_db.with_database(fn(connection) {
+    let kairos_config = build_config(connection)
+    let contract = mail_worker()
+    let args = MailArgs(recipient: "ops@example.com", template: "welcome")
+
+    let assert Ok(enqueued) = kairos.enqueue(kairos_config, contract, args)
+    let job.EnqueuedJob(
+      id: id,
+      args: stored_args,
+      worker_name: worker_name,
+      state: state,
+      queue_name: queue_name,
+      priority: priority,
+      attempt: attempt,
+      max_attempts: max_attempts,
+      scheduled_at: scheduled_at,
+      ..,
+    ) = enqueued
+
+    assert stored_args == args
+    assert worker_name == "mailers.email"
+    assert state == job.Pending
+    assert queue_name == "mailers"
+    assert priority == 3
+    assert attempt == 0
+    assert max_attempts == 5
+
+    let assert Ok(Some(stored)) = job_store.fetch(connection, id)
+    let job_store.PersistedJob(
+      payload: payload,
+      state: stored_state,
+      queue_name: stored_queue,
+      priority: stored_priority,
+      max_attempts: stored_max_attempts,
+      scheduled_at: stored_at,
+      ..,
+    ) = stored
+
+    assert payload == worker.encode(contract, args)
+    assert stored_state == job.Pending
+    assert stored_queue == "mailers"
+    assert stored_priority == 3
+    assert stored_max_attempts == 5
+    assert scheduled_at == stored_at
+  })
+}
+
+pub fn enqueue_with_supports_delayed_execution_test() {
+  test_db.with_database(fn(connection) {
+    let kairos_config = build_config(connection)
+    let contract = mail_worker()
+    let args = MailArgs(recipient: "slow@example.com", template: "digest")
+    let now = timestamp.system_time()
+    let later = timestamp.add(now, duration.minutes(10))
+    let assert Ok(queued) =
+      job.with_queue(worker.default_options(contract), "default")
+    let assert Ok(retrying) = job.with_max_attempts(queued, 2)
+    let prioritized = job.with_priority(retrying, 8)
+    let options = job.with_schedule(prioritized, job.At(later))
+
+    let assert Ok(enqueued) =
+      kairos.enqueue_with(kairos_config, contract, args, options)
+    let job.EnqueuedJob(
+      id: id,
+      args: stored_args,
+      state: state,
+      queue_name: queue_name,
+      priority: priority,
+      max_attempts: max_attempts,
+      scheduled_at: scheduled_at,
+      ..,
+    ) = enqueued
+
+    assert stored_args == args
+    assert state == job.Scheduled
+    assert queue_name == "default"
+    assert priority == 8
+    assert max_attempts == 2
+    assert scheduled_at == test_db.to_postgres_precision(later)
+
+    let assert Ok(Some(stored)) = job_store.fetch(connection, id)
+    let job_store.PersistedJob(state: stored_state, scheduled_at: stored_at, ..) =
+      stored
+
+    assert stored_state == job.Scheduled
+    assert stored_at == test_db.to_postgres_precision(later)
+  })
+}
+
+pub fn enqueue_with_rejects_unknown_queues_test() {
+  test_db.with_database(fn(connection) {
+    let kairos_config = build_config(connection)
+    let contract = mail_worker()
+    let args = MailArgs(recipient: "ops@example.com", template: "welcome")
+    let assert Ok(options) =
+      job.with_queue(worker.default_options(contract), "unknown")
+
+    assert kairos.enqueue_with(kairos_config, contract, args, options)
+      == Error(kairos.QueueNotConfigured("unknown"))
+
+    let assert Ok(stored_jobs) =
+      job_store.fetch_available(connection, timestamp.system_time(), 10)
+    assert stored_jobs == []
+  })
+}
+
+fn build_config(connection: pog.Connection) -> config.Config {
+  let assert Ok(default_queue) =
+    queue.new(name: "default", concurrency: 10, poll_interval_ms: 1000)
+  let assert Ok(mailers_queue) =
+    queue.new(name: "mailers", concurrency: 5, poll_interval_ms: 2000)
+  let assert Ok(kairos_config) =
+    config.new(connection: connection, queues: [default_queue, mailers_queue])
+  kairos_config
+}
+
+fn mail_worker() -> worker.Worker(MailArgs) {
+  let assert Ok(queue_options) =
+    job.with_queue(job.default_enqueue_options(), "mailers")
+  let assert Ok(retry_options) = job.with_max_attempts(queue_options, 5)
+  let options = job.with_priority(retry_options, 3)
+
+  worker.new(
+    "mailers.email",
+    encode_mail_args,
+    fn(_payload) { Error(worker.DecodeError("not used in enqueue tests")) },
+    fn(_args) { worker.Success },
+    options,
+  )
+}
+
+fn encode_mail_args(args: MailArgs) -> String {
+  let MailArgs(recipient:, template:) = args
+  recipient <> "|" <> template
+}

--- a/test/kairos/job_test.gleam
+++ b/test/kairos/job_test.gleam
@@ -1,3 +1,5 @@
+import gleam/time/duration
+import gleam/time/timestamp
 import gleeunit
 import kairos/job
 
@@ -30,4 +32,26 @@ pub fn job_state_round_trip_test() {
   assert job.state_from_string("discarded") == Ok(job.Discarded)
   assert job.state_from_string("cancelled") == Ok(job.Cancelled)
   assert job.state_from_string("unknown") == Error(Nil)
+}
+
+pub fn enqueue_options_can_be_updated_test() {
+  let now = timestamp.system_time()
+  let scheduled_at = timestamp.add(now, duration.minutes(15))
+  let assert Ok(queued) =
+    job.with_queue(job.default_enqueue_options(), "mailers")
+  let assert Ok(retrying) = job.with_max_attempts(queued, 5)
+  let prioritized = job.with_priority(retrying, 9)
+  let scheduled = job.with_schedule(prioritized, job.At(scheduled_at))
+
+  assert job.queue(scheduled) == "mailers"
+  assert job.max_attempts(scheduled) == 5
+  assert job.priority(scheduled) == 9
+  assert job.schedule(scheduled) == job.At(scheduled_at)
+}
+
+pub fn enqueue_options_reject_invalid_values_test() {
+  assert job.with_queue(job.default_enqueue_options(), "   ")
+    == Error(job.BlankQueueName)
+  assert job.with_max_attempts(job.default_enqueue_options(), 0)
+    == Error(job.NonPositiveMaxAttempts)
 }


### PR DESCRIPTION
## Summary

Adds the first public enqueue boundary for Kairos backed by the existing PostgreSQL store.

- add `kairos.enqueue/3` and `kairos.enqueue_with/4`
- add typed enqueue option builders and a typed `job.EnqueuedJob(args)` return record
- validate configured queue names before persisting jobs
- cover immediate enqueue, delayed enqueue, invalid queue, and enqueue option behavior with tests

## Why

Issue #5 calls for the first end-to-end enqueue path that keeps the caller-facing API typed while persisting jobs through PostgreSQL.

Closes #5.

## Impact

Callers can now enqueue typed worker arguments through the public Kairos API without constructing raw PostgreSQL job records directly.

## Validation

- `gleam format`
- `gleam test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job enqueueing API to submit work to configured queues with validation and explicit errors for unknown queues
  * Configurable enqueue options: queue selection, priority, retry attempts, and delayed scheduling
  * Enqueued jobs return rich state and timestamps for scheduling, attempts, and completion

* **Tests**
  * Added test suites covering enqueue behavior, delayed scheduling, persistence, and option validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->