### PR TITLE
Add repository automation foundation

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  review_details: false
+  collapse_walkthrough: true
+  changed_files_summary: true
+  sequence_diagrams: false
+  estimate_code_review_effort: false
+  related_issues: true
+  related_prs: false
+  poem: false
+  enable_prompt_for_ai_agents: false
+  path_filters:
+    - "!manifest.toml"
+  path_instructions:
+    - path: "src/**/*.gleam"
+      instructions: |
+        Review Kairos source changes for domain clarity, boundary separation, and explicit costs.
+        Flag hidden coupling, storage details leaking into caller-facing APIs, silent error swallowing, and queue or job state changes that could break invariants.
+    - path: "test/**/*.gleam"
+      instructions: |
+        Focus on behavior coverage, regression protection, and clear failure intent.
+        Prefer comments about missing edge cases or overly coupled assertions over style nits.
+    - path: ".github/workflows/**"
+      instructions: |
+        Focus on least-privilege permissions, deterministic job names, reasonable caching, and practical CI runtime.
+        Flag workflow steps that are hard to maintain or that make required checks brittle.
+    - path: "**/*.md"
+      instructions: |
+        Review documentation for accuracy against the current codebase, especially API names, setup steps, and review workflow guidance.
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: true
+
+chat:
+  auto_reply: false
+  art: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ concurrency:
 
 env:
   GLEAM_VERSION: "1.14.0"
-  POSTGRES_VERSION: "16"
 
 jobs:
   format:
@@ -49,7 +48,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:${{ env.POSTGRES_VERSION }}
+        image: postgres:16
         env:
           POSTGRES_DB: kairos_test
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GLEAM_VERSION: "1.14.0"
+  POSTGRES_VERSION: "16"
+
+jobs:
+  format:
+    name: format
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Gleam and OTP
+        uses: erlef/setup-beam@v1
+        with:
+          gleam-version: ${{ env.GLEAM_VERSION }}
+          otp-version: "28"
+
+      - name: Check formatting
+        run: gleam format --check src test
+
+  verify:
+    name: verify (otp ${{ matrix.otp }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        otp:
+          - "27"
+          - "28"
+
+    services:
+      postgres:
+        image: postgres:${{ env.POSTGRES_VERSION }}
+        env:
+          POSTGRES_DB: kairos_test
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d kairos_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      KAIROS_TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/kairos_test?sslmode=disable
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Gleam and OTP
+        uses: erlef/setup-beam@v1
+        with:
+          gleam-version: ${{ env.GLEAM_VERSION }}
+          otp-version: ${{ matrix.otp }}
+
+      - name: Cache Gleam and rebar artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/packages
+            ~/.cache/rebar3
+          key: ${{ runner.os }}-otp-${{ matrix.otp }}-gleam-${{ env.GLEAM_VERSION }}-${{ hashFiles('gleam.toml', 'manifest.toml') }}
+
+      - name: Download dependencies
+        run: gleam deps download
+
+      - name: Build
+        run: gleam check
+
+      - name: Test
+        run: gleam test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   format:
     name: format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:
@@ -36,7 +36,7 @@ jobs:
 
   verify:
     name: verify (otp ${{ matrix.otp }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           gleam-version: ${{ env.GLEAM_VERSION }}
           otp-version: ${{ matrix.otp }}
+          rebar3-version: "3"
 
       - name: Cache Gleam and rebar artifacts
         uses: actions/cache@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+## Local Verification Loop
+
+Kairos keeps the local verification loop small:
+
+```sh
+gleam format
+gleam check
+gleam test
+```
+
+Integration tests require PostgreSQL. By default they use:
+
+```sh
+postgresql://postgres:postgres@localhost:5432/kairos_test?sslmode=disable
+```
+
+Override that by setting `KAIROS_TEST_DATABASE_URL`.
+
+## CI Support Policy
+
+The baseline CI workflow in `.github/workflows/ci.yml` currently supports:
+
+- Gleam `1.14.0`
+- Erlang/OTP `27`
+- Erlang/OTP `28`
+
+This matrix is the repository’s compatibility floor for day-to-day changes. Expand the matrix only when the project intentionally broadens support, and remove versions only with an explicit support decision.
+
+## Required Checks For `main`
+
+Branch protection for `main` should require these checks:
+
+- `format`
+- `verify (otp 27)`
+- `verify (otp 28)`
+
+These checks cover the baseline merge gate:
+
+- formatting stays enforced
+- the codebase builds on the supported OTP matrix
+- tests stay green on every supported OTP target
+
+Keep job names stable once branch protection is enabled. If a workflow job name changes, update branch protection in the repository settings in the same maintenance window.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,3 +43,22 @@ These checks cover the baseline merge gate:
 - tests stay green on every supported OTP target
 
 Keep job names stable once branch protection is enabled. If a workflow job name changes, update branch protection in the repository settings in the same maintenance window.
+
+## CodeRabbit
+
+Kairos uses repository-level CodeRabbit defaults from `.coderabbit.yaml`.
+
+CodeRabbit is part of the review workflow, but it is not the final reviewer:
+
+- treat CodeRabbit findings like any other review feedback and triage them by correctness, risk, and relevance
+- fix or answer substantive findings before merge
+- do not treat every nitpick as blocking when it does not improve correctness, maintainability, or clarity
+- keep human review responsible for architecture, invariants, and merge decisions
+
+The current defaults are tuned for signal over noise:
+
+- automatic review is enabled on non-draft pull requests
+- walkthrough noise is reduced by disabling poems, sequence diagrams, and AI-agent prompts
+- source, tests, workflows, and Markdown each get targeted review instructions
+
+If CodeRabbit becomes noisy again, adjust `.coderabbit.yaml` in version control rather than relying on ad hoc repository UI settings.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,203 @@
+Copyright 2026 Cristiano Carvalho
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Cristiano Carvalho
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -93,3 +93,5 @@ createdb kairos_test
 gleam format
 gleam test
 ```
+
+See `CONTRIBUTING.md` for the CI support policy and required merge checks.

--- a/README.md
+++ b/README.md
@@ -94,4 +94,4 @@ gleam format
 gleam test
 ```
 
-See `CONTRIBUTING.md` for the CI support policy and required merge checks.
+See `CONTRIBUTING.md` for the CI support policy, required merge checks, and CodeRabbit review defaults.

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,6 @@
 name = "kairos"
 version = "0.1.0"
+licences = ["Apache-2.0"]
 description = "A background job runner for Gleam on the BEAM."
 repository = { type = "github", user = "ccarvalho-eng", repo = "kairos" }
 


### PR DESCRIPTION
## Summary

Adds the remaining repository foundation automation and review defaults for Kairos.

- add a baseline GitHub Actions CI workflow for pull requests and `main`
- document the supported Gleam and OTP matrix plus the required merge checks for branch protection
- add repository-level CodeRabbit defaults tuned for signal over noise
- document how CodeRabbit fits alongside human review in the contributor workflow
- add the Apache 2.0 license and package license metadata

## Why

These changes complete the repository guardrails needed for day-to-day development and review consistency.

Closes #24.
Closes #25.

## Impact

Contributors now have a defined baseline verification loop, CI support policy, stable required checks for `main`, explicit CodeRabbit defaults, and checked-in license metadata.

## Validation

- YAML syntax check for `.github/workflows/ci.yml` and `.coderabbit.yaml`
- `gleam format --check src test`
- `gleam check`
- `gleam test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidelines with local verification, CI support policy, and CodeRabbit review expectations.
  * Updated README to point to contributor guidance.
  * Added project LICENSE (Apache-2.0).

* **Chores**
  * Enabled CI checks for formatting, verification, and matrix testing on PRs/merges.
  * Enabled automated code review and review configuration defaults.
  * Added license metadata to project config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->