### PR TITLE
Add README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Kairos
 
+[![CI](https://github.com/ccarvalho-eng/kairos/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ccarvalho-eng/kairos/actions/workflows/ci.yml)
+[![Language: Gleam](https://img.shields.io/badge/language-Gleam-ffaff3)](https://gleam.run)
+[![License: Apache-2.0](https://img.shields.io/github/license/ccarvalho-eng/kairos)](./LICENSE)
+
 Kairos is a background job runner for Gleam on the BEAM with typed worker contracts, PostgreSQL-backed persistence, and explicit queue configuration.
 
 Kairos is in early `0.x` development. The package API and supervision behavior are still being established.


### PR DESCRIPTION
## Summary

Adds repository badges to the README header.

- add a CI status badge for the `CI` workflow on `main`
- add a Gleam language badge
- add an Apache 2.0 license badge

## Why

These badges make the project status and stack easier to scan from the repository landing page.

## Validation

- README preview only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CI status, Gleam language, and License badges to README for quick reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->