### PR TITLE
Implement queue polling and atomic job claiming

### DIFF
--- a/src/kairos/postgres/job_store.gleam
+++ b/src/kairos/postgres/job_store.gleam
@@ -132,6 +132,22 @@ pub fn fetch_available(
   |> map_many_row_result
 }
 
+pub fn claim_available(
+  connection: db.Connection,
+  queue_name: String,
+  now: timestamp.Timestamp,
+  limit: Int,
+) -> Result(List(PersistedJob), StoreError) {
+  query.claim_available()
+  |> db.query
+  |> db.parameter(db.text(queue_name))
+  |> db.parameter(db.timestamp(now))
+  |> db.parameter(db.int(limit))
+  |> db.returning(raw_job.decoder())
+  |> db.execute(connection)
+  |> map_many_row_result
+}
+
 fn map_single_row_result(
   result: Result(db.Returned(raw_job.RawPersistedJob), db.QueryError),
 ) -> Result(PersistedJob, StoreError) {

--- a/src/kairos/postgres/job_store/query.gleam
+++ b/src/kairos/postgres/job_store/query.gleam
@@ -33,72 +33,14 @@ pub fn insert() -> String {
     $13::TIMESTAMPTZ,
     $14::TIMESTAMPTZ
   )
-  RETURNING
-    id::TEXT,
-    worker_name,
-    payload,
-    state,
-    queue_name,
-    priority,
-    attempt,
-    max_attempts,
-    unique_key,
-    errors,
-    (EXTRACT(EPOCH FROM scheduled_at) * 1000000)::BIGINT,
-    CASE
-      WHEN attempted_at IS NULL THEN NULL
-      ELSE (EXTRACT(EPOCH FROM attempted_at) * 1000000)::BIGINT
-    END,
-    CASE
-      WHEN completed_at IS NULL THEN NULL
-      ELSE (EXTRACT(EPOCH FROM completed_at) * 1000000)::BIGINT
-    END,
-    CASE
-      WHEN discarded_at IS NULL THEN NULL
-      ELSE (EXTRACT(EPOCH FROM discarded_at) * 1000000)::BIGINT
-    END,
-    CASE
-      WHEN cancelled_at IS NULL THEN NULL
-      ELSE (EXTRACT(EPOCH FROM cancelled_at) * 1000000)::BIGINT
-    END,
-    (EXTRACT(EPOCH FROM inserted_at) * 1000000)::BIGINT,
-    (EXTRACT(EPOCH FROM updated_at) * 1000000)::BIGINT
-  "
+  " <> returned_columns("kairos_jobs")
 }
 
 @internal
 pub fn fetch() -> String {
   "
   SELECT
-    id::TEXT,
-    worker_name,
-    payload,
-    state,
-    queue_name,
-    priority,
-    attempt,
-    max_attempts,
-    unique_key,
-    errors,
-    (EXTRACT(EPOCH FROM scheduled_at) * 1000000)::BIGINT,
-    CASE
-      WHEN attempted_at IS NULL THEN NULL
-      ELSE (EXTRACT(EPOCH FROM attempted_at) * 1000000)::BIGINT
-    END,
-    CASE
-      WHEN completed_at IS NULL THEN NULL
-      ELSE (EXTRACT(EPOCH FROM completed_at) * 1000000)::BIGINT
-    END,
-    CASE
-      WHEN discarded_at IS NULL THEN NULL
-      ELSE (EXTRACT(EPOCH FROM discarded_at) * 1000000)::BIGINT
-    END,
-    CASE
-      WHEN cancelled_at IS NULL THEN NULL
-      ELSE (EXTRACT(EPOCH FROM cancelled_at) * 1000000)::BIGINT
-    END,
-    (EXTRACT(EPOCH FROM inserted_at) * 1000000)::BIGINT,
-    (EXTRACT(EPOCH FROM updated_at) * 1000000)::BIGINT
+  " <> selected_columns("kairos_jobs") <> "
   FROM kairos_jobs
   WHERE id = $1
   "
@@ -108,39 +50,75 @@ pub fn fetch() -> String {
 pub fn fetch_available() -> String {
   "
   SELECT
-    id::TEXT,
-    worker_name,
-    payload,
-    state,
-    queue_name,
-    priority,
-    attempt,
-    max_attempts,
-    unique_key,
-    errors,
-    (EXTRACT(EPOCH FROM scheduled_at) * 1000000)::BIGINT,
-    CASE
-      WHEN attempted_at IS NULL THEN NULL
-      ELSE (EXTRACT(EPOCH FROM attempted_at) * 1000000)::BIGINT
-    END,
-    CASE
-      WHEN completed_at IS NULL THEN NULL
-      ELSE (EXTRACT(EPOCH FROM completed_at) * 1000000)::BIGINT
-    END,
-    CASE
-      WHEN discarded_at IS NULL THEN NULL
-      ELSE (EXTRACT(EPOCH FROM discarded_at) * 1000000)::BIGINT
-    END,
-    CASE
-      WHEN cancelled_at IS NULL THEN NULL
-      ELSE (EXTRACT(EPOCH FROM cancelled_at) * 1000000)::BIGINT
-    END,
-    (EXTRACT(EPOCH FROM inserted_at) * 1000000)::BIGINT,
-    (EXTRACT(EPOCH FROM updated_at) * 1000000)::BIGINT
+  " <> selected_columns("kairos_jobs") <> "
   FROM kairos_jobs
   WHERE state IN ('pending', 'scheduled', 'retryable')
     AND scheduled_at <= $1
   ORDER BY priority DESC, scheduled_at ASC, inserted_at ASC
   LIMIT $2
   "
+}
+
+@internal
+pub fn claim_available() -> String {
+  "
+  WITH claimable AS (
+    SELECT id
+    FROM kairos_jobs
+    WHERE queue_name = $1
+      AND state IN ('pending', 'scheduled', 'retryable')
+      AND scheduled_at <= $2
+      AND attempt < max_attempts
+    ORDER BY priority DESC, scheduled_at ASC, inserted_at ASC
+    LIMIT $3
+    FOR UPDATE SKIP LOCKED
+  )
+  UPDATE kairos_jobs
+  SET
+    state = 'executing',
+    attempt = kairos_jobs.attempt + 1,
+    attempted_at = $2
+  FROM claimable
+  WHERE kairos_jobs.id = claimable.id
+  " <> returned_columns("kairos_jobs")
+}
+
+fn selected_columns(table_name: String) -> String {
+  "
+    " <> table_name <> ".id::TEXT,
+    " <> table_name <> ".worker_name,
+    " <> table_name <> ".payload,
+    " <> table_name <> ".state,
+    " <> table_name <> ".queue_name,
+    " <> table_name <> ".priority,
+    " <> table_name <> ".attempt,
+    " <> table_name <> ".max_attempts,
+    " <> table_name <> ".unique_key,
+    " <> table_name <> ".errors,
+    (EXTRACT(EPOCH FROM " <> table_name <> ".scheduled_at) * 1000000)::BIGINT,
+    CASE
+      WHEN " <> table_name <> ".attempted_at IS NULL THEN NULL
+      ELSE (EXTRACT(EPOCH FROM " <> table_name <> ".attempted_at) * 1000000)::BIGINT
+    END,
+    CASE
+      WHEN " <> table_name <> ".completed_at IS NULL THEN NULL
+      ELSE (EXTRACT(EPOCH FROM " <> table_name <> ".completed_at) * 1000000)::BIGINT
+    END,
+    CASE
+      WHEN " <> table_name <> ".discarded_at IS NULL THEN NULL
+      ELSE (EXTRACT(EPOCH FROM " <> table_name <> ".discarded_at) * 1000000)::BIGINT
+    END,
+    CASE
+      WHEN " <> table_name <> ".cancelled_at IS NULL THEN NULL
+      ELSE (EXTRACT(EPOCH FROM " <> table_name <> ".cancelled_at) * 1000000)::BIGINT
+    END,
+    (EXTRACT(EPOCH FROM " <> table_name <> ".inserted_at) * 1000000)::BIGINT,
+    (EXTRACT(EPOCH FROM " <> table_name <> ".updated_at) * 1000000)::BIGINT
+  "
+}
+
+fn returned_columns(table_name: String) -> String {
+  "
+  RETURNING
+  " <> selected_columns(table_name)
 }

--- a/src/kairos/postgres/job_store/query.gleam
+++ b/src/kairos/postgres/job_store/query.gleam
@@ -54,6 +54,7 @@ pub fn fetch_available() -> String {
   FROM kairos_jobs
   WHERE state IN ('pending', 'scheduled', 'retryable')
     AND scheduled_at <= $1
+    AND attempt < max_attempts
   ORDER BY priority DESC, scheduled_at ASC, inserted_at ASC
   LIMIT $2
   "

--- a/src/kairos/queue_poller.gleam
+++ b/src/kairos/queue_poller.gleam
@@ -1,0 +1,18 @@
+import gleam/time/timestamp
+import kairos/postgres/job_store
+import kairos/queue
+import pog
+
+@internal
+pub fn poll(
+  connection: pog.Connection,
+  queue_definition: queue.Queue,
+  now: timestamp.Timestamp,
+) -> Result(List(job_store.PersistedJob), job_store.StoreError) {
+  job_store.claim_available(
+    connection,
+    queue.name(queue_definition),
+    now,
+    queue.concurrency(queue_definition),
+  )
+}

--- a/test/kairos/postgres/job_store_available_test.gleam
+++ b/test/kairos/postgres/job_store_available_test.gleam
@@ -182,6 +182,39 @@ pub fn retryable_and_terminal_state_round_trip_test() {
     assert discarded_at == Some(expected_now)
     assert discarded_errors == ["poison payload"]
 
+    let assert Ok(_) =
+      job_store.insert(
+        connection,
+        job_store.JobInsert(
+          worker_name: "ExhaustedRetryableWorker",
+          payload: "{}",
+          state: job.Retryable,
+          queue_name: "default",
+          priority: 10,
+          attempt: 5,
+          max_attempts: 5,
+          unique_key: None,
+          errors: ["max attempts reached"],
+          scheduled_at: now,
+          attempted_at: Some(now),
+          completed_at: None,
+          discarded_at: None,
+          cancelled_at: None,
+        ),
+      )
+
+    let assert Ok(available_after_exhausted) =
+      job_store.fetch_available(connection, now, 10)
+    let available_names =
+      available_after_exhausted
+      |> list.map(fn(job) {
+        let job_store.PersistedJob(worker_name:, ..) = job
+        worker_name
+      })
+
+    assert list.contains(available_names, "RetryableWorker")
+    assert !list.contains(available_names, "ExhaustedRetryableWorker")
+
     let assert Ok(Some(fetched_retryable)) =
       job_store.fetch(connection, retryable_id)
     let assert Ok(Some(fetched_completed)) =

--- a/test/kairos/postgres/job_store_claim_test.gleam
+++ b/test/kairos/postgres/job_store_claim_test.gleam
@@ -1,0 +1,241 @@
+import gleam/list
+import gleam/option.{None, Some}
+import gleam/time/duration
+import gleam/time/timestamp
+import gleeunit
+import kairos/job
+import kairos/postgres/job_store
+import kairos/postgres/test_db
+import pog
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+pub fn claim_available_claims_only_runnable_jobs_for_the_queue_test() {
+  test_db.with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let earlier = timestamp.add(now, duration.seconds(-30))
+    let later = timestamp.add(now, duration.minutes(5))
+
+    let assert Ok(_) =
+      insert_job(
+        connection,
+        worker_name: "RetryableWorker",
+        state: job.Retryable,
+        queue_name: "default",
+        priority: 5,
+        attempt: 1,
+        max_attempts: 3,
+        scheduled_at: earlier,
+      )
+    let assert Ok(_) =
+      insert_job(
+        connection,
+        worker_name: "PendingWorker",
+        state: job.Pending,
+        queue_name: "default",
+        priority: 1,
+        attempt: 0,
+        max_attempts: 3,
+        scheduled_at: now,
+      )
+    let assert Ok(mailers) =
+      insert_job(
+        connection,
+        worker_name: "MailersWorker",
+        state: job.Pending,
+        queue_name: "mailers",
+        priority: 10,
+        attempt: 0,
+        max_attempts: 3,
+        scheduled_at: now,
+      )
+    let assert Ok(scheduled) =
+      insert_job(
+        connection,
+        worker_name: "ScheduledWorker",
+        state: job.Scheduled,
+        queue_name: "default",
+        priority: 10,
+        attempt: 0,
+        max_attempts: 3,
+        scheduled_at: later,
+      )
+    let assert Ok(exhausted) =
+      insert_job(
+        connection,
+        worker_name: "ExhaustedWorker",
+        state: job.Retryable,
+        queue_name: "default",
+        priority: 9,
+        attempt: 3,
+        max_attempts: 3,
+        scheduled_at: earlier,
+      )
+
+    let assert Ok(claimed) =
+      job_store.claim_available(connection, "default", now, 10)
+
+    let assert [first, second] = claimed
+    let expected_now = test_db.to_postgres_precision(now)
+
+    assert claimed_worker_names(claimed)
+      == [
+        "RetryableWorker",
+        "PendingWorker",
+      ]
+
+    let job_store.PersistedJob(
+      id: retryable_id,
+      state: retryable_state,
+      attempt: retryable_attempt,
+      attempted_at: retryable_attempted_at,
+      ..,
+    ) = first
+    let job_store.PersistedJob(
+      id: pending_id,
+      state: pending_state,
+      attempt: pending_attempt,
+      attempted_at: pending_attempted_at,
+      ..,
+    ) = second
+
+    assert retryable_state == job.Executing
+    assert pending_state == job.Executing
+    assert retryable_attempt == 2
+    assert pending_attempt == 1
+    assert retryable_attempted_at == Some(expected_now)
+    assert pending_attempted_at == Some(expected_now)
+
+    let job_store.PersistedJob(id: scheduled_id, ..) = scheduled
+    let job_store.PersistedJob(id: exhausted_id, ..) = exhausted
+
+    assert_job_state(connection, retryable_id, job.Executing)
+    assert_job_state(connection, pending_id, job.Executing)
+    assert_job_state(connection, scheduled_id, job.Scheduled)
+    assert_job_state(connection, exhausted_id, job.Retryable)
+
+    let job_store.PersistedJob(id: mailers_id, ..) = mailers
+    assert_job_state(connection, mailers_id, job.Pending)
+  })
+}
+
+pub fn claim_available_does_not_reclaim_already_claimed_jobs_test() {
+  test_db.with_database(fn(connection) {
+    let now = timestamp.system_time()
+
+    let assert Ok(_) =
+      insert_job(
+        connection,
+        worker_name: "FirstWorker",
+        state: job.Pending,
+        queue_name: "default",
+        priority: 10,
+        attempt: 0,
+        max_attempts: 3,
+        scheduled_at: now,
+      )
+    let assert Ok(_) =
+      insert_job(
+        connection,
+        worker_name: "SecondWorker",
+        state: job.Pending,
+        queue_name: "default",
+        priority: 5,
+        attempt: 0,
+        max_attempts: 3,
+        scheduled_at: now,
+      )
+    let assert Ok(_) =
+      insert_job(
+        connection,
+        worker_name: "ThirdWorker",
+        state: job.Pending,
+        queue_name: "default",
+        priority: 1,
+        attempt: 0,
+        max_attempts: 3,
+        scheduled_at: now,
+      )
+
+    let assert Ok(first_claim) =
+      job_store.claim_available(connection, "default", now, 2)
+    let assert Ok(second_claim) =
+      job_store.claim_available(connection, "default", now, 2)
+
+    assert claimed_worker_names(first_claim) == ["FirstWorker", "SecondWorker"]
+    assert claimed_worker_names(second_claim) == ["ThirdWorker"]
+
+    let claimed_ids =
+      first_claim
+      |> list.append(second_claim)
+      |> list.map(fn(claimed_job) {
+        let job_store.PersistedJob(id:, ..) = claimed_job
+        id
+      })
+
+    assert list.length(claimed_ids) == 3
+    assert list.unique(claimed_ids) == claimed_ids
+
+    let assert Ok(third_claim) =
+      job_store.claim_available(connection, "default", now, 2)
+    assert third_claim == []
+  })
+}
+
+fn insert_job(
+  connection: pog.Connection,
+  worker_name worker_name: String,
+  state state: job.JobState,
+  queue_name queue_name: String,
+  priority priority: Int,
+  attempt attempt: Int,
+  max_attempts max_attempts: Int,
+  scheduled_at scheduled_at: timestamp.Timestamp,
+) -> Result(job_store.PersistedJob, job_store.StoreError) {
+  let attempted_at = case attempt > 0 {
+    True -> Some(scheduled_at)
+    False -> None
+  }
+
+  job_store.insert(
+    connection,
+    job_store.JobInsert(
+      worker_name: worker_name,
+      payload: "{}",
+      state: state,
+      queue_name: queue_name,
+      priority: priority,
+      attempt: attempt,
+      max_attempts: max_attempts,
+      unique_key: None,
+      errors: [],
+      scheduled_at: scheduled_at,
+      attempted_at: attempted_at,
+      completed_at: None,
+      discarded_at: None,
+      cancelled_at: None,
+    ),
+  )
+}
+
+fn claimed_worker_names(
+  claimed_jobs: List(job_store.PersistedJob),
+) -> List(String) {
+  claimed_jobs
+  |> list.map(fn(claimed_job) {
+    let job_store.PersistedJob(worker_name:, ..) = claimed_job
+    worker_name
+  })
+}
+
+fn assert_job_state(
+  connection: pog.Connection,
+  id: String,
+  expected_state: job.JobState,
+) -> Nil {
+  let assert Ok(Some(persisted_job)) = job_store.fetch(connection, id)
+  let job_store.PersistedJob(state:, ..) = persisted_job
+  assert state == expected_state
+}

--- a/test/kairos/queue_poller_test.gleam
+++ b/test/kairos/queue_poller_test.gleam
@@ -1,0 +1,66 @@
+import gleam/list
+import gleam/option.{None}
+import gleam/time/timestamp
+import gleeunit
+import kairos/job
+import kairos/postgres/job_store
+import kairos/postgres/test_db
+import kairos/queue
+import kairos/queue_poller
+import pog
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+pub fn poll_claims_up_to_queue_concurrency_test() {
+  test_db.with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let assert Ok(queue_definition) =
+      queue.new(name: "default", concurrency: 2, poll_interval_ms: 1000)
+
+    let assert Ok(_) = insert_pending(connection, "FirstWorker", now, 10)
+    let assert Ok(_) = insert_pending(connection, "SecondWorker", now, 5)
+    let assert Ok(_) = insert_pending(connection, "ThirdWorker", now, 1)
+
+    let assert Ok(claimed) =
+      queue_poller.poll(connection, queue_definition, now)
+
+    assert worker_names(claimed) == ["FirstWorker", "SecondWorker"]
+  })
+}
+
+fn insert_pending(
+  connection: pog.Connection,
+  worker_name: String,
+  scheduled_at: timestamp.Timestamp,
+  priority: Int,
+) -> Result(job_store.PersistedJob, job_store.StoreError) {
+  job_store.insert(
+    connection,
+    job_store.JobInsert(
+      worker_name: worker_name,
+      payload: "{}",
+      state: job.Pending,
+      queue_name: "default",
+      priority: priority,
+      attempt: 0,
+      max_attempts: 3,
+      unique_key: None,
+      errors: [],
+      scheduled_at: scheduled_at,
+      attempted_at: None,
+      completed_at: None,
+      discarded_at: None,
+      cancelled_at: None,
+    ),
+  )
+}
+
+fn worker_names(claimed_jobs: List(job_store.PersistedJob)) -> List(String) {
+  claimed_jobs
+  |> list.map(fn(claimed_job) {
+    let job_store.PersistedJob(worker_name:, ..) = claimed_job
+    worker_name
+  })
+}


### PR DESCRIPTION
## Summary

Implements the first queue polling and claiming slice for Kairos.

- add an atomic PostgreSQL claim query scoped to a queue
- transition claimed jobs to `executing`, increment `attempt`, and stamp `attempted_at`
- add a thin queue poll helper that claims up to the queue concurrency limit
- add PostgreSQL integration coverage for deterministic ordering, runnable filtering, and non-duplicate claiming

## Why

This turns persisted jobs into claimable work and establishes the contract the execution runtime can build on next.

Closes #6.

## Impact

Kairos can now claim runnable jobs per queue with deterministic ordering and atomic SQL semantics, which unblocks runner and lifecycle work.

## Validation

- `gleam format`
- `gleam test`
- `25 passed, no failures`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Jobs can now be claimed from queues with enforced concurrency limits, atomically transitioning to executing state with attempt tracking and timestamps.

* **Tests**
  * Added comprehensive test coverage for job claiming behavior, including concurrency enforcement, state transitions, and idempotency validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->