### PR TITLE
Add job runners and lifecycle dispatch

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -5,6 +5,7 @@ description = "A background job runner for Gleam on the BEAM."
 repository = { type = "github", user = "ccarvalho-eng", repo = "kairos" }
 
 [dependencies]
+exception = ">= 2.1.0 and < 3.0.0"
 gleam_erlang = ">= 1.0.0 and < 2.0.0"
 gleam_otp = ">= 1.0.0 and < 2.0.0"
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -18,6 +18,7 @@ packages = [
 
 [requirements]
 envoy = { version = ">= 1.1.0 and < 2.0.0" }
+exception = { version = ">= 2.1.0 and < 3.0.0" }
 gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_otp = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }

--- a/src/kairos/config.gleam
+++ b/src/kairos/config.gleam
@@ -1,26 +1,39 @@
 import gleam/list
+import gleam/option.{type Option, None, Some}
 import kairos/queue
+import kairos/worker
 import pog
 
 pub type ConfigError {
   EmptyQueues
   DuplicateQueueName(String)
+  DuplicateWorkerName(String)
 }
 
 pub opaque type Config {
-  Config(connection: pog.Connection, queues: List(queue.Queue))
+  Config(
+    connection: pog.Connection,
+    queues: List(queue.Queue),
+    workers: List(worker.RegisteredWorker),
+  )
 }
 
 pub fn new(
   connection connection: pog.Connection,
   queues queues: List(queue.Queue),
+  workers workers: List(worker.RegisteredWorker),
 ) -> Result(Config, ConfigError) {
   case queues {
     [] -> Error(EmptyQueues)
     _ -> {
-      case find_duplicate_queue_name(queues, seen: []) {
-        Ok(Nil) -> Ok(Config(connection: connection, queues: queues))
-        Error(queue_name) -> Error(DuplicateQueueName(queue_name))
+      case
+        find_duplicate_queue_name(queues, seen: []),
+        find_duplicate_worker_name(workers, seen: [])
+      {
+        Ok(Nil), Ok(Nil) ->
+          Ok(Config(connection: connection, queues: queues, workers: workers))
+        Error(queue_name), _ -> Error(DuplicateQueueName(queue_name))
+        _, Error(worker_name) -> Error(DuplicateWorkerName(worker_name))
       }
     }
   }
@@ -36,6 +49,20 @@ pub fn queues(config: Config) -> List(queue.Queue) {
   queues
 }
 
+@internal
+pub fn workers(config: Config) -> List(worker.RegisteredWorker) {
+  let Config(workers:, ..) = config
+  workers
+}
+
+@internal
+pub fn find_worker(
+  config: Config,
+  worker_name: String,
+) -> Option(worker.RegisteredWorker) {
+  find_worker_in_list(workers(config), worker_name)
+}
+
 fn find_duplicate_queue_name(
   queues: List(queue.Queue),
   seen seen: List(String),
@@ -49,5 +76,35 @@ fn find_duplicate_queue_name(
         False -> find_duplicate_queue_name(rest, seen: [queue_name, ..seen])
       }
     }
+  }
+}
+
+fn find_duplicate_worker_name(
+  workers: List(worker.RegisteredWorker),
+  seen seen: List(String),
+) -> Result(Nil, String) {
+  case workers {
+    [] -> Ok(Nil)
+    [registered_worker, ..rest] -> {
+      let worker_name = worker.registered_name(registered_worker)
+      case list.any(seen, fn(seen_name) { seen_name == worker_name }) {
+        True -> Error(worker_name)
+        False -> find_duplicate_worker_name(rest, seen: [worker_name, ..seen])
+      }
+    }
+  }
+}
+
+fn find_worker_in_list(
+  workers: List(worker.RegisteredWorker),
+  worker_name: String,
+) -> Option(worker.RegisteredWorker) {
+  case workers {
+    [] -> None
+    [registered_worker, ..rest] ->
+      case worker.registered_name(registered_worker) == worker_name {
+        True -> Some(registered_worker)
+        False -> find_worker_in_list(rest, worker_name)
+      }
   }
 }

--- a/src/kairos/job_runner.gleam
+++ b/src/kairos/job_runner.gleam
@@ -1,8 +1,11 @@
 import gleam/erlang/process
+import gleam/float
 import gleam/int
+import gleam/io
 import gleam/option.{None, Some}
 import gleam/otp/actor
 import gleam/string
+import gleam/time/duration
 import gleam/time/timestamp
 import kairos/config
 import kairos/postgres/job_store
@@ -30,7 +33,13 @@ pub fn start(argument: RunnerArg) -> actor.StartResult(String) {
   let job_store.PersistedJob(id:, ..) = job
   let pid =
     process.spawn(fn() {
-      let assert Ok(_) = run(argument)
+      case run(argument) {
+        Ok(_) -> Nil
+        Error(error) ->
+          io.println(
+            "kairos runner persistence failed: " <> string.inspect(error),
+          )
+      }
       Nil
     })
   Ok(actor.Started(pid:, data: id))
@@ -50,7 +59,12 @@ fn run(
 ) -> Result(job_store.PersistedJob, job_store.StoreError) {
   let RunnerArg(config:, job: claimed_job, now:) = argument
   let transition = determine_transition(config, claimed_job)
-  persist_transition(config.connection(config), claimed_job, now, transition)
+  persist_or_recover_transition(
+    config.connection(config),
+    claimed_job,
+    now,
+    transition,
+  )
 }
 
 fn determine_transition(
@@ -112,10 +126,59 @@ fn persist_transition(
 
   case transition {
     MarkCompleted -> job_store.complete(connection, id, now)
-    MarkRetryable(error) -> job_store.retry(connection, id, now, error)
+    MarkRetryable(error) ->
+      job_store.retry(
+        connection,
+        id,
+        retry_scheduled_at(claimed_job, now),
+        error,
+      )
     MarkDiscarded(error) -> job_store.discard(connection, id, now, error)
     MarkCancelled(error) -> job_store.cancel(connection, id, now, error)
   }
+}
+
+fn persist_or_recover_transition(
+  connection: pog.Connection,
+  claimed_job: job_store.PersistedJob,
+  now: timestamp.Timestamp,
+  transition: LifecycleTransition,
+) -> Result(job_store.PersistedJob, job_store.StoreError) {
+  case persist_transition(connection, claimed_job, now, transition) {
+    Ok(persisted_job) -> Ok(persisted_job)
+    Error(error) ->
+      recover_transition_failure(connection, claimed_job, now, error)
+  }
+}
+
+fn recover_transition_failure(
+  connection: pog.Connection,
+  claimed_job: job_store.PersistedJob,
+  now: timestamp.Timestamp,
+  error: job_store.StoreError,
+) -> Result(job_store.PersistedJob, job_store.StoreError) {
+  let job_store.PersistedJob(id:, attempt:, ..) = claimed_job
+  let recovery_error =
+    format_failure("persistence", attempt, string.inspect(error))
+
+  job_store.retry(
+    connection,
+    id,
+    retry_scheduled_at(claimed_job, now),
+    recovery_error,
+  )
+}
+
+@internal
+pub fn retry_scheduled_at(
+  claimed_job: job_store.PersistedJob,
+  now: timestamp.Timestamp,
+) -> timestamp.Timestamp {
+  let job_store.PersistedJob(attempt:, max_attempts:, ..) = claimed_job
+  timestamp.add(
+    now,
+    duration.seconds(default_backoff_seconds(attempt, max_attempts)),
+  )
 }
 
 fn format_failure(kind: String, attempt: Int, reason: String) -> String {
@@ -125,4 +188,21 @@ fn format_failure(kind: String, attempt: Int, reason: String) -> String {
   <> int.to_string(attempt)
   <> " reason="
   <> string.replace(reason, "\n", " ")
+}
+
+fn default_backoff_seconds(attempt: Int, max_attempts: Int) -> Int {
+  let clamped_attempt = case max_attempts <= 20 {
+    True -> attempt
+    False ->
+      float.round(int.to_float(attempt) /. int.to_float(max_attempts) *. 20.0)
+  }
+
+  15 + pow2(int.min(clamped_attempt, 20))
+}
+
+fn pow2(exponent: Int) -> Int {
+  case exponent <= 0 {
+    True -> 1
+    False -> 2 * pow2(exponent - 1)
+  }
 }

--- a/src/kairos/job_runner.gleam
+++ b/src/kairos/job_runner.gleam
@@ -1,0 +1,128 @@
+import gleam/erlang/process
+import gleam/int
+import gleam/option.{None, Some}
+import gleam/otp/actor
+import gleam/string
+import gleam/time/timestamp
+import kairos/config
+import kairos/postgres/job_store
+import kairos/worker
+import pog
+
+pub type RunnerArg {
+  RunnerArg(
+    config: config.Config,
+    job: job_store.PersistedJob,
+    now: timestamp.Timestamp,
+  )
+}
+
+type LifecycleTransition {
+  MarkCompleted
+  MarkRetryable(String)
+  MarkDiscarded(String)
+  MarkCancelled(String)
+}
+
+@internal
+pub fn start(argument: RunnerArg) -> actor.StartResult(String) {
+  let RunnerArg(job:, ..) = argument
+  let job_store.PersistedJob(id:, ..) = job
+  let pid =
+    process.spawn(fn() {
+      let assert Ok(_) = run(argument)
+      Nil
+    })
+  Ok(actor.Started(pid:, data: id))
+}
+
+@internal
+pub fn run_claimed(
+  config: config.Config,
+  claimed_job: job_store.PersistedJob,
+  now: timestamp.Timestamp,
+) -> Result(job_store.PersistedJob, job_store.StoreError) {
+  run(RunnerArg(config:, job: claimed_job, now: now))
+}
+
+fn run(
+  argument: RunnerArg,
+) -> Result(job_store.PersistedJob, job_store.StoreError) {
+  let RunnerArg(config:, job: claimed_job, now:) = argument
+  let transition = determine_transition(config, claimed_job)
+  persist_transition(config.connection(config), claimed_job, now, transition)
+}
+
+fn determine_transition(
+  config: config.Config,
+  claimed_job: job_store.PersistedJob,
+) -> LifecycleTransition {
+  let job_store.PersistedJob(
+    worker_name: worker_name,
+    payload: payload,
+    attempt: attempt,
+    max_attempts: max_attempts,
+    ..,
+  ) = claimed_job
+
+  case config.find_worker(config, worker_name) {
+    Some(registered_worker) ->
+      case worker.execute_payload(registered_worker, payload) {
+        worker.Succeeded -> MarkCompleted
+        worker.RetryRequested(reason) ->
+          retry_or_discard(attempt, max_attempts, "retry", reason)
+        worker.DiscardRequested(reason) ->
+          MarkDiscarded(format_failure("discard", attempt, reason))
+        worker.CancelRequested(reason) ->
+          MarkCancelled(format_failure("cancel", attempt, reason))
+        worker.DecodeFailed(reason) ->
+          MarkDiscarded(format_failure("decode", attempt, reason))
+        worker.Crashed(reason) ->
+          retry_or_discard(attempt, max_attempts, "crash", reason)
+      }
+    None ->
+      MarkDiscarded(format_failure(
+        "missing_worker",
+        attempt,
+        "worker not configured",
+      ))
+  }
+}
+
+fn retry_or_discard(
+  attempt: Int,
+  max_attempts: Int,
+  kind: String,
+  reason: String,
+) -> LifecycleTransition {
+  let formatted = format_failure(kind, attempt, reason)
+  case attempt < max_attempts {
+    True -> MarkRetryable(formatted)
+    False -> MarkDiscarded(formatted)
+  }
+}
+
+fn persist_transition(
+  connection: pog.Connection,
+  claimed_job: job_store.PersistedJob,
+  now: timestamp.Timestamp,
+  transition: LifecycleTransition,
+) -> Result(job_store.PersistedJob, job_store.StoreError) {
+  let job_store.PersistedJob(id:, ..) = claimed_job
+
+  case transition {
+    MarkCompleted -> job_store.complete(connection, id, now)
+    MarkRetryable(error) -> job_store.retry(connection, id, now, error)
+    MarkDiscarded(error) -> job_store.discard(connection, id, now, error)
+    MarkCancelled(error) -> job_store.cancel(connection, id, now, error)
+  }
+}
+
+fn format_failure(kind: String, attempt: Int, reason: String) -> String {
+  "kind="
+  <> kind
+  <> " attempt="
+  <> int.to_string(attempt)
+  <> " reason="
+  <> string.replace(reason, "\n", " ")
+}

--- a/src/kairos/job_runner.gleam
+++ b/src/kairos/job_runner.gleam
@@ -147,7 +147,13 @@ fn persist_or_recover_transition(
   case persist_transition(connection, claimed_job, now, transition) {
     Ok(persisted_job) -> Ok(persisted_job)
     Error(error) ->
-      recover_transition_failure(connection, claimed_job, now, error)
+      recover_transition_failure(
+        connection,
+        claimed_job,
+        now,
+        transition,
+        error,
+      )
   }
 }
 
@@ -155,18 +161,27 @@ fn recover_transition_failure(
   connection: pog.Connection,
   claimed_job: job_store.PersistedJob,
   now: timestamp.Timestamp,
+  transition: LifecycleTransition,
   error: job_store.StoreError,
 ) -> Result(job_store.PersistedJob, job_store.StoreError) {
-  let job_store.PersistedJob(id:, attempt:, ..) = claimed_job
+  let job_store.PersistedJob(id:, attempt:, max_attempts:, ..) = claimed_job
   let recovery_error =
     format_failure("persistence", attempt, string.inspect(error))
 
-  job_store.retry(
-    connection,
-    id,
-    retry_scheduled_at(claimed_job, now),
-    recovery_error,
-  )
+  case transition {
+    MarkRetryable(_) ->
+      case attempt < max_attempts {
+        True ->
+          job_store.retry(
+            connection,
+            id,
+            retry_scheduled_at(claimed_job, now),
+            recovery_error,
+          )
+        False -> Error(error)
+      }
+    _ -> Error(error)
+  }
 }
 
 @internal

--- a/src/kairos/postgres/job_store.gleam
+++ b/src/kairos/postgres/job_store.gleam
@@ -148,6 +148,68 @@ pub fn claim_available(
   |> map_many_row_result
 }
 
+pub fn complete(
+  connection: db.Connection,
+  id: String,
+  completed_at: timestamp.Timestamp,
+) -> Result(PersistedJob, StoreError) {
+  query.complete()
+  |> db.query
+  |> db.parameter(db.text(id))
+  |> db.parameter(db.timestamp(completed_at))
+  |> db.returning(raw_job.decoder())
+  |> db.execute(connection)
+  |> map_single_row_result
+}
+
+pub fn retry(
+  connection: db.Connection,
+  id: String,
+  scheduled_at: timestamp.Timestamp,
+  error: String,
+) -> Result(PersistedJob, StoreError) {
+  query.retry()
+  |> db.query
+  |> db.parameter(db.text(id))
+  |> db.parameter(db.timestamp(scheduled_at))
+  |> db.parameter(db.text(error))
+  |> db.returning(raw_job.decoder())
+  |> db.execute(connection)
+  |> map_single_row_result
+}
+
+pub fn discard(
+  connection: db.Connection,
+  id: String,
+  discarded_at: timestamp.Timestamp,
+  error: String,
+) -> Result(PersistedJob, StoreError) {
+  query.discard()
+  |> db.query
+  |> db.parameter(db.text(id))
+  |> db.parameter(db.timestamp(discarded_at))
+  |> db.parameter(db.text(error))
+  |> db.returning(raw_job.decoder())
+  |> db.execute(connection)
+  |> map_single_row_result
+}
+
+pub fn cancel(
+  connection: db.Connection,
+  id: String,
+  cancelled_at: timestamp.Timestamp,
+  error: String,
+) -> Result(PersistedJob, StoreError) {
+  query.cancel()
+  |> db.query
+  |> db.parameter(db.text(id))
+  |> db.parameter(db.timestamp(cancelled_at))
+  |> db.parameter(db.text(error))
+  |> db.returning(raw_job.decoder())
+  |> db.execute(connection)
+  |> map_single_row_result
+}
+
 fn map_single_row_result(
   result: Result(db.Returned(raw_job.RawPersistedJob), db.QueryError),
 ) -> Result(PersistedJob, StoreError) {

--- a/src/kairos/postgres/job_store/query.gleam
+++ b/src/kairos/postgres/job_store/query.gleam
@@ -84,6 +84,53 @@ pub fn claim_available() -> String {
   " <> returned_columns("kairos_jobs")
 }
 
+@internal
+pub fn complete() -> String {
+  "
+  UPDATE kairos_jobs
+  SET
+    state = 'completed',
+    completed_at = $2
+  WHERE id = $1
+  " <> returned_columns("kairos_jobs")
+}
+
+@internal
+pub fn retry() -> String {
+  "
+  UPDATE kairos_jobs
+  SET
+    state = 'retryable',
+    scheduled_at = $2,
+    errors = array_append(kairos_jobs.errors, $3::TEXT)
+  WHERE id = $1
+  " <> returned_columns("kairos_jobs")
+}
+
+@internal
+pub fn discard() -> String {
+  "
+  UPDATE kairos_jobs
+  SET
+    state = 'discarded',
+    discarded_at = $2,
+    errors = array_append(kairos_jobs.errors, $3::TEXT)
+  WHERE id = $1
+  " <> returned_columns("kairos_jobs")
+}
+
+@internal
+pub fn cancel() -> String {
+  "
+  UPDATE kairos_jobs
+  SET
+    state = 'cancelled',
+    cancelled_at = $2,
+    errors = array_append(kairos_jobs.errors, $3::TEXT)
+  WHERE id = $1
+  " <> returned_columns("kairos_jobs")
+}
+
 fn selected_columns(table_name: String) -> String {
   "
     " <> table_name <> ".id::TEXT,

--- a/src/kairos/postgres/job_store/query.gleam
+++ b/src/kairos/postgres/job_store/query.gleam
@@ -92,6 +92,7 @@ pub fn complete() -> String {
     state = 'completed',
     completed_at = $2
   WHERE id = $1
+    AND state = 'executing'
   " <> returned_columns("kairos_jobs")
 }
 
@@ -104,6 +105,7 @@ pub fn retry() -> String {
     scheduled_at = $2,
     errors = array_append(kairos_jobs.errors, $3::TEXT)
   WHERE id = $1
+    AND state = 'executing'
   " <> returned_columns("kairos_jobs")
 }
 
@@ -116,6 +118,7 @@ pub fn discard() -> String {
     discarded_at = $2,
     errors = array_append(kairos_jobs.errors, $3::TEXT)
   WHERE id = $1
+    AND state = 'executing'
   " <> returned_columns("kairos_jobs")
 }
 
@@ -128,6 +131,7 @@ pub fn cancel() -> String {
     cancelled_at = $2,
     errors = array_append(kairos_jobs.errors, $3::TEXT)
   WHERE id = $1
+    AND state = 'executing'
   " <> returned_columns("kairos_jobs")
 }
 

--- a/src/kairos/queue_dispatcher.gleam
+++ b/src/kairos/queue_dispatcher.gleam
@@ -1,0 +1,70 @@
+import gleam/erlang/process
+import gleam/list
+import gleam/otp/actor
+import gleam/otp/factory_supervisor
+import gleam/result
+import gleam/time/timestamp
+import kairos/config
+import kairos/job_runner
+import kairos/postgres/job_store
+import kairos/queue
+import kairos/queue_poller
+import kairos/supervision
+
+pub type DispatchError {
+  QueueRuntimeUnavailable(String)
+  ClaimFailed(job_store.StoreError)
+  RunnerStartFailed(actor.StartError)
+}
+
+pub fn dispatch(
+  config: config.Config,
+  queue_definition: queue.Queue,
+  runtime: supervision.Runtime,
+  now: timestamp.Timestamp,
+) -> Result(List(process.Pid), DispatchError) {
+  let queue_name = queue.name(queue_definition)
+  let runner_supervisor_pid =
+    supervision.queue_runner_supervisor_pid(runtime, queue_name)
+    |> result.map_error(fn(_) { QueueRuntimeUnavailable(queue_name) })
+  use _ <- result.try(runner_supervisor_pid)
+  let runner_supervisor_name =
+    supervision.queue_runner_supervisor_name(runtime, queue_name)
+    |> result.map_error(fn(_) { QueueRuntimeUnavailable(queue_name) })
+  use runner_supervisor_name <- result.try(runner_supervisor_name)
+
+  let claimed_jobs =
+    queue_poller.poll(config.connection(config), queue_definition, now)
+    |> result.map_error(ClaimFailed)
+  use claimed_jobs <- result.try(claimed_jobs)
+
+  let runner_supervisor = factory_supervisor.get_by_name(runner_supervisor_name)
+
+  start_claimed_jobs(runner_supervisor, config, claimed_jobs, now, [])
+}
+
+fn start_claimed_jobs(
+  runner_supervisor: factory_supervisor.Supervisor(job_runner.RunnerArg, String),
+  config: config.Config,
+  claimed_jobs: List(job_store.PersistedJob),
+  now: timestamp.Timestamp,
+  started_pids: List(process.Pid),
+) -> Result(List(process.Pid), DispatchError) {
+  case claimed_jobs {
+    [] -> Ok(list.reverse(started_pids))
+    [claimed_job, ..rest] -> {
+      let start_result =
+        factory_supervisor.start_child(
+          runner_supervisor,
+          job_runner.RunnerArg(config:, job: claimed_job, now: now),
+        )
+        |> result.map_error(RunnerStartFailed)
+
+      use started <- result.try(start_result)
+      start_claimed_jobs(runner_supervisor, config, rest, now, [
+        started.pid,
+        ..started_pids
+      ])
+    }
+  }
+}

--- a/src/kairos/queue_dispatcher.gleam
+++ b/src/kairos/queue_dispatcher.gleam
@@ -1,8 +1,10 @@
 import gleam/erlang/process
+import gleam/int
 import gleam/list
 import gleam/otp/actor
 import gleam/otp/factory_supervisor
 import gleam/result
+import gleam/string
 import gleam/time/timestamp
 import kairos/config
 import kairos/job_runner
@@ -10,11 +12,13 @@ import kairos/postgres/job_store
 import kairos/queue
 import kairos/queue_poller
 import kairos/supervision
+import pog
 
 pub type DispatchError {
   QueueRuntimeUnavailable(String)
   ClaimFailed(job_store.StoreError)
   RunnerStartFailed(actor.StartError)
+  ReleaseClaimedFailed(actor.StartError, job_store.StoreError)
 }
 
 pub fn dispatch(
@@ -53,18 +57,63 @@ fn start_claimed_jobs(
   case claimed_jobs {
     [] -> Ok(list.reverse(started_pids))
     [claimed_job, ..rest] -> {
-      let start_result =
+      case
         factory_supervisor.start_child(
           runner_supervisor,
           job_runner.RunnerArg(config:, job: claimed_job, now: now),
         )
-        |> result.map_error(RunnerStartFailed)
+      {
+        Ok(started) ->
+          start_claimed_jobs(runner_supervisor, config, rest, now, [
+            started.pid,
+            ..started_pids
+          ])
 
-      use started <- result.try(start_result)
-      start_claimed_jobs(runner_supervisor, config, rest, now, [
-        started.pid,
-        ..started_pids
-      ])
+        Error(start_error) ->
+          case
+            release_claimed_jobs(
+              config.connection(config),
+              [claimed_job, ..rest],
+              now,
+              start_error,
+            )
+          {
+            Ok(Nil) -> Error(RunnerStartFailed(start_error))
+            Error(cleanup_error) ->
+              Error(ReleaseClaimedFailed(start_error, cleanup_error))
+          }
+      }
     }
   }
+}
+
+fn release_claimed_jobs(
+  connection: pog.Connection,
+  claimed_jobs: List(job_store.PersistedJob),
+  now: timestamp.Timestamp,
+  start_error: actor.StartError,
+) -> Result(Nil, job_store.StoreError) {
+  case claimed_jobs {
+    [] -> Ok(Nil)
+    [claimed_job, ..rest] -> {
+      let job_store.PersistedJob(id:, attempt:, ..) = claimed_job
+      use _ <- result.try(job_store.retry(
+        connection,
+        id,
+        job_runner.retry_scheduled_at(claimed_job, now),
+        format_dispatch_failure(attempt, start_error),
+      ))
+      release_claimed_jobs(connection, rest, now, start_error)
+    }
+  }
+}
+
+fn format_dispatch_failure(
+  attempt: Int,
+  start_error: actor.StartError,
+) -> String {
+  "kind=runner_start attempt="
+  <> int.to_string(attempt)
+  <> " reason="
+  <> string.replace(string.inspect(start_error), "\n", " ")
 }

--- a/src/kairos/supervision.gleam
+++ b/src/kairos/supervision.gleam
@@ -2,10 +2,12 @@ import gleam/dict
 import gleam/erlang/process
 import gleam/list
 import gleam/otp/actor
+import gleam/otp/factory_supervisor
 import gleam/otp/static_supervisor
 import gleam/otp/supervision.{type ChildSpecification}
 import gleam/result
 import kairos/config
+import kairos/job_runner
 import kairos/supervision/name
 import kairos/supervision/queue_runtime
 import kairos/supervision/queue_supervisor
@@ -88,12 +90,24 @@ pub fn queue_supervisor_pid(
 }
 
 @internal
-pub fn queue_worker_pid(
+pub fn queue_runner_supervisor_pid(
   runtime: Runtime,
   queue_name: String,
 ) -> Result(process.Pid, Nil) {
   use runtime_for_queue <- result.try(find_queue_runtime(runtime, queue_name))
-  queue_runtime.worker_pid(runtime_for_queue)
+  queue_runtime.runner_supervisor_pid(runtime_for_queue)
+}
+
+@internal
+pub fn queue_runner_supervisor_name(
+  runtime: Runtime,
+  queue_name: String,
+) -> Result(
+  process.Name(factory_supervisor.Message(job_runner.RunnerArg, String)),
+  Nil,
+) {
+  use runtime_for_queue <- result.try(find_queue_runtime(runtime, queue_name))
+  Ok(queue_runtime.runner_supervisor_name(runtime_for_queue))
 }
 
 @internal

--- a/src/kairos/supervision/name.gleam
+++ b/src/kairos/supervision/name.gleam
@@ -1,5 +1,7 @@
 import gleam/erlang/process
+import gleam/otp/factory_supervisor
 import gleam/string
+import kairos/job_runner
 
 @internal
 pub fn root_supervisor() -> process.Name(Nil) {
@@ -12,8 +14,10 @@ pub fn queue_supervisor(queue_name: String) -> process.Name(Nil) {
 }
 
 @internal
-pub fn queue_worker(queue_name: String) -> process.Name(Nil) {
-  process.new_name("kairos-queue-worker-" <> sanitize(queue_name))
+pub fn queue_runner_supervisor(
+  queue_name: String,
+) -> process.Name(factory_supervisor.Message(job_runner.RunnerArg, String)) {
+  process.new_name("kairos-queue-runner-" <> sanitize(queue_name))
 }
 
 @internal

--- a/src/kairos/supervision/queue_runtime.gleam
+++ b/src/kairos/supervision/queue_runtime.gleam
@@ -1,4 +1,6 @@
 import gleam/erlang/process
+import gleam/otp/factory_supervisor
+import kairos/job_runner
 import kairos/queue
 import kairos/supervision/name
 
@@ -6,7 +8,9 @@ pub opaque type QueueRuntime {
   QueueRuntime(
     name: String,
     supervisor_name: process.Name(Nil),
-    worker_name: process.Name(Nil),
+    runner_supervisor_name: process.Name(
+      factory_supervisor.Message(job_runner.RunnerArg, String),
+    ),
     poller_name: process.Name(Nil),
   )
 }
@@ -18,7 +22,7 @@ pub fn from_queue(queue_definition: queue.Queue) -> QueueRuntime {
   QueueRuntime(
     name: queue_name,
     supervisor_name: name.queue_supervisor(queue_name),
-    worker_name: name.queue_worker(queue_name),
+    runner_supervisor_name: name.queue_runner_supervisor(queue_name),
     poller_name: name.queue_poller(queue_name),
   )
 }
@@ -35,9 +39,11 @@ pub fn supervisor_name(runtime: QueueRuntime) -> process.Name(Nil) {
 }
 
 @internal
-pub fn worker_name(runtime: QueueRuntime) -> process.Name(Nil) {
-  let QueueRuntime(worker_name:, ..) = runtime
-  worker_name
+pub fn runner_supervisor_name(
+  runtime: QueueRuntime,
+) -> process.Name(factory_supervisor.Message(job_runner.RunnerArg, String)) {
+  let QueueRuntime(runner_supervisor_name:, ..) = runtime
+  runner_supervisor_name
 }
 
 @internal
@@ -52,8 +58,8 @@ pub fn supervisor_pid(runtime: QueueRuntime) -> Result(process.Pid, Nil) {
 }
 
 @internal
-pub fn worker_pid(runtime: QueueRuntime) -> Result(process.Pid, Nil) {
-  process.named(worker_name(runtime))
+pub fn runner_supervisor_pid(runtime: QueueRuntime) -> Result(process.Pid, Nil) {
+  process.named(runner_supervisor_name(runtime))
 }
 
 @internal

--- a/src/kairos/supervision/queue_supervisor.gleam
+++ b/src/kairos/supervision/queue_supervisor.gleam
@@ -1,6 +1,8 @@
 import gleam/otp/actor
+import gleam/otp/factory_supervisor
 import gleam/otp/static_supervisor
 import gleam/otp/supervision.{type ChildSpecification}
+import kairos/job_runner
 import kairos/supervision/queue_runtime
 import kairos/supervision/registered_supervisor
 import kairos/supervision/stub_actor
@@ -12,7 +14,9 @@ pub fn start(
   let builder =
     static_supervisor.new(static_supervisor.OneForAll)
     |> static_supervisor.add(
-      stub_actor.supervised(name: queue_runtime.worker_name(runtime)),
+      factory_supervisor.worker_child(job_runner.start)
+      |> factory_supervisor.named(queue_runtime.runner_supervisor_name(runtime))
+      |> factory_supervisor.supervised,
     )
     |> static_supervisor.add(
       stub_actor.supervised(name: queue_runtime.poller_name(runtime)),

--- a/src/kairos/worker.gleam
+++ b/src/kairos/worker.gleam
@@ -3,6 +3,8 @@
 //// Worker definitions in this module encode typed arguments into a persisted
 //// string payload and decode them again before execution.
 
+import exception
+import gleam/string
 import kairos/job
 
 pub type DecodeError {
@@ -16,6 +18,15 @@ pub type PerformResult {
   Cancel(String)
 }
 
+pub type PayloadExecutionResult {
+  Succeeded
+  RetryRequested(String)
+  DiscardRequested(String)
+  CancelRequested(String)
+  DecodeFailed(String)
+  Crashed(String)
+}
+
 pub opaque type Worker(args) {
   Worker(
     name: String,
@@ -23,6 +34,13 @@ pub opaque type Worker(args) {
     decoder: fn(String) -> Result(args, DecodeError),
     performer: fn(args) -> PerformResult,
     default_options: job.EnqueueOptions,
+  )
+}
+
+pub opaque type RegisteredWorker {
+  RegisteredWorker(
+    name: String,
+    execute_payload: fn(String) -> PayloadExecutionResult,
   )
 }
 
@@ -70,4 +88,59 @@ pub fn decode(
 pub fn perform(contract: Worker(args), args: args) -> PerformResult {
   let Worker(performer:, ..) = contract
   performer(args)
+}
+
+pub fn register(contract: Worker(args)) -> RegisteredWorker {
+  RegisteredWorker(name: name(contract), execute_payload: fn(payload) {
+    run_payload(contract, payload)
+  })
+}
+
+pub fn registered_name(registered_worker: RegisteredWorker) -> String {
+  let RegisteredWorker(name:, ..) = registered_worker
+  name
+}
+
+@internal
+pub fn execute_payload(
+  registered_worker: RegisteredWorker,
+  payload: String,
+) -> PayloadExecutionResult {
+  let RegisteredWorker(execute_payload:, ..) = registered_worker
+  execute_payload(payload)
+}
+
+fn run_payload(
+  contract: Worker(args),
+  payload: String,
+) -> PayloadExecutionResult {
+  case
+    exception.rescue(fn() {
+      case decode(contract, payload) {
+        Ok(args) -> Ok(perform(contract, args))
+        Error(DecodeError(reason)) -> Error(DecodeFailed(reason))
+      }
+    })
+  {
+    Ok(Ok(result)) -> map_perform_result(result)
+    Ok(Error(decode_error)) -> decode_error
+    Error(error) -> Crashed(format_exception(error))
+  }
+}
+
+fn map_perform_result(result: PerformResult) -> PayloadExecutionResult {
+  case result {
+    Success -> Succeeded
+    Retry(reason) -> RetryRequested(reason)
+    Discard(reason) -> DiscardRequested(reason)
+    Cancel(reason) -> CancelRequested(reason)
+  }
+}
+
+fn format_exception(error: exception.Exception) -> String {
+  case error {
+    exception.Errored(dynamic) -> "errored: " <> string.inspect(dynamic)
+    exception.Thrown(dynamic) -> "thrown: " <> string.inspect(dynamic)
+    exception.Exited(dynamic) -> "exited: " <> string.inspect(dynamic)
+  }
 }

--- a/test/kairos/config_test.gleam
+++ b/test/kairos/config_test.gleam
@@ -46,6 +46,20 @@ pub fn config_rejects_duplicate_worker_names_test() {
     ])
 }
 
+pub fn config_accepts_distinct_worker_names_test() {
+  let connection = test_connection()
+  let assert Ok(default_queue) =
+    queue.new(name: "default", concurrency: 10, poll_interval_ms: 1000)
+  let worker_one = worker.register(example_worker("mailers.email"))
+  let worker_two = worker.register(example_worker("mailers.digest"))
+
+  let assert Ok(_) =
+    config.new(connection: connection, queues: [default_queue], workers: [
+      worker_one,
+      worker_two,
+    ])
+}
+
 fn test_connection() -> pog.Connection {
   pog.named_connection(process.new_name("kairos-test-pool"))
 }

--- a/test/kairos/config_test.gleam
+++ b/test/kairos/config_test.gleam
@@ -1,7 +1,9 @@
 import gleam/erlang/process
 import gleeunit
 import kairos/config
+import kairos/job
 import kairos/queue
+import kairos/worker
 import pog
 
 pub fn main() -> Nil {
@@ -16,16 +18,44 @@ pub fn config_rejects_duplicate_queue_names_test() {
     queue.new(name: "default", concurrency: 5, poll_interval_ms: 500)
 
   let assert Error(config.DuplicateQueueName("default")) =
-    config.new(connection: connection, queues: [first_queue, second_queue])
+    config.new(
+      connection: connection,
+      queues: [first_queue, second_queue],
+      workers: [],
+    )
 }
 
 pub fn config_requires_at_least_one_queue_test() {
   let connection = test_connection()
 
-  assert config.new(connection: connection, queues: [])
+  assert config.new(connection: connection, queues: [], workers: [])
     == Error(config.EmptyQueues)
+}
+
+pub fn config_rejects_duplicate_worker_names_test() {
+  let connection = test_connection()
+  let assert Ok(default_queue) =
+    queue.new(name: "default", concurrency: 10, poll_interval_ms: 1000)
+  let worker_one = worker.register(example_worker("mailers.email"))
+  let worker_two = worker.register(example_worker("mailers.email"))
+
+  let assert Error(config.DuplicateWorkerName("mailers.email")) =
+    config.new(connection: connection, queues: [default_queue], workers: [
+      worker_one,
+      worker_two,
+    ])
 }
 
 fn test_connection() -> pog.Connection {
   pog.named_connection(process.new_name("kairos-test-pool"))
+}
+
+fn example_worker(name: String) -> worker.Worker(String) {
+  worker.new(
+    name,
+    fn(payload) { payload },
+    fn(payload) { Ok(payload) },
+    fn(_payload) { worker.Success },
+    job.default_enqueue_options(),
+  )
 }

--- a/test/kairos/enqueue_test.gleam
+++ b/test/kairos/enqueue_test.gleam
@@ -132,7 +132,11 @@ fn build_config(connection: pog.Connection) -> config.Config {
   let assert Ok(mailers_queue) =
     queue.new(name: "mailers", concurrency: 5, poll_interval_ms: 2000)
   let assert Ok(kairos_config) =
-    config.new(connection: connection, queues: [default_queue, mailers_queue])
+    config.new(
+      connection: connection,
+      queues: [default_queue, mailers_queue],
+      workers: [],
+    )
   kairos_config
 }
 

--- a/test/kairos/job_runner_test.gleam
+++ b/test/kairos/job_runner_test.gleam
@@ -1,3 +1,4 @@
+import gleam/dynamic/decode
 import gleam/list
 import gleam/option.{None, Some}
 import gleam/string
@@ -242,6 +243,46 @@ pub fn run_claimed_appends_retry_history_test() {
   })
 }
 
+pub fn run_claimed_does_not_requeue_completed_jobs_when_persist_fails_test() {
+  test_db.with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let contract = result_worker("workers.success", worker.Success)
+    let kairos_config = build_config(connection, [worker.register(contract)])
+    let claimed = enqueue_and_claim(kairos_config, contract, now)
+    let job_store.PersistedJob(id:, ..) = claimed
+
+    let assert Ok(_) =
+      pog.query("ALTER TABLE kairos_jobs DROP COLUMN completed_at")
+      |> pog.execute(connection)
+
+    let assert Error(job_store.QueryFailed(_)) =
+      job_runner.run_claimed(kairos_config, claimed, now)
+
+    assert job_state(connection, id) == "executing"
+  })
+}
+
+pub fn run_claimed_does_not_requeue_exhausted_jobs_when_discard_fails_test() {
+  test_db.with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let contract =
+      result_worker("workers.exhausted", worker.Retry("retry later"))
+    let kairos_config = build_config(connection, [worker.register(contract)])
+    let claimed =
+      enqueue_and_claim_with_attempts(kairos_config, contract, 1, now)
+    let job_store.PersistedJob(id:, ..) = claimed
+
+    let assert Ok(_) =
+      pog.query("ALTER TABLE kairos_jobs DROP COLUMN discarded_at")
+      |> pog.execute(connection)
+
+    let assert Error(job_store.QueryFailed(_)) =
+      job_runner.run_claimed(kairos_config, claimed, now)
+
+    assert job_state(connection, id) == "executing"
+  })
+}
+
 fn build_config(
   connection: pog.Connection,
   registered_workers: List(worker.RegisteredWorker),
@@ -411,6 +452,21 @@ fn assert_cancelled(
   assert cancelled_at == Some(expected_now)
   let assert [error] = errors
   assert string.contains(error, reason_substring)
+}
+
+fn job_state(connection: pog.Connection, id: String) -> String {
+  let decoder = {
+    use state <- decode.field(0, decode.string)
+    decode.success(state)
+  }
+
+  let assert Ok(pog.Returned(rows: [state], ..)) =
+    pog.query("SELECT state FROM kairos_jobs WHERE id = $1")
+    |> pog.parameter(pog.text(id))
+    |> pog.returning(decoder)
+    |> pog.execute(connection)
+
+  state
 }
 
 fn result_worker(

--- a/test/kairos/job_runner_test.gleam
+++ b/test/kairos/job_runner_test.gleam
@@ -1,0 +1,353 @@
+import gleam/option.{None, Some}
+import gleam/string
+import gleam/time/timestamp
+import gleeunit
+import kairos
+import kairos/config
+import kairos/job
+import kairos/job_runner
+import kairos/postgres/job_store
+import kairos/postgres/test_db
+import kairos/queue
+import kairos/worker
+import pog
+
+type ExampleArgs {
+  ExampleArgs(name: String)
+}
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+pub fn run_claimed_marks_successful_jobs_completed_test() {
+  test_db.with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let contract = result_worker("workers.success", worker.Success)
+    let kairos_config = build_config(connection, [worker.register(contract)])
+    let claimed = enqueue_and_claim(kairos_config, contract, now)
+
+    let assert Ok(finished) =
+      job_runner.run_claimed(kairos_config, claimed, now)
+    let expected_now = test_db.to_postgres_precision(now)
+
+    let job_store.PersistedJob(
+      id: id,
+      state: state,
+      completed_at: completed_at,
+      errors: errors,
+      ..,
+    ) = finished
+
+    assert state == job.Completed
+    assert completed_at == Some(expected_now)
+    assert errors == []
+
+    let assert Ok(Some(stored)) = job_store.fetch(connection, id)
+    let job_store.PersistedJob(state: stored_state, ..) = stored
+    assert stored_state == job.Completed
+  })
+}
+
+pub fn run_claimed_persists_retry_discard_and_cancel_outcomes_test() {
+  test_db.with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let retry_contract =
+      result_worker("workers.retry", worker.Retry("retry later"))
+    let kairos_config =
+      build_config(connection, [worker.register(retry_contract)])
+    let retried = enqueue_and_run_claimed(kairos_config, retry_contract, now)
+    let expected_now = test_db.to_postgres_precision(now)
+
+    assert_retryable(retried, expected_now, "kind=retry", "retry later")
+  })
+}
+
+pub fn run_claimed_persists_discard_outcome_test() {
+  test_db.with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let discard_contract =
+      result_worker("workers.discard", worker.Discard("discard permanently"))
+    let kairos_config =
+      build_config(connection, [worker.register(discard_contract)])
+    let discarded =
+      enqueue_and_run_claimed(kairos_config, discard_contract, now)
+
+    let expected_now = test_db.to_postgres_precision(now)
+    assert_discarded(discarded, expected_now, "discard permanently")
+  })
+}
+
+pub fn run_claimed_persists_cancel_outcome_test() {
+  test_db.with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let cancel_contract =
+      result_worker("workers.cancel", worker.Cancel("cancel execution"))
+    let kairos_config =
+      build_config(connection, [worker.register(cancel_contract)])
+    let cancelled = enqueue_and_run_claimed(kairos_config, cancel_contract, now)
+
+    let expected_now = test_db.to_postgres_precision(now)
+    assert_cancelled(cancelled, expected_now, "cancel execution")
+  })
+}
+
+pub fn run_claimed_discards_decode_failures_and_missing_workers_test() {
+  test_db.with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let decode_contract = decode_failure_worker("workers.decode")
+    let kairos_config =
+      build_config(connection, [worker.register(decode_contract)])
+
+    let malformed_job =
+      insert_executing_job(
+        connection,
+        worker_name: "workers.decode",
+        payload: "bad payload",
+        max_attempts: 3,
+        attempt: 1,
+        attempted_at: now,
+      )
+    let missing_worker_job =
+      insert_executing_job(
+        connection,
+        worker_name: "workers.missing",
+        payload: "kairos",
+        max_attempts: 3,
+        attempt: 1,
+        attempted_at: now,
+      )
+
+    let decode_failed = run_claimed(kairos_config, malformed_job, now)
+    let missing_worker = run_claimed(kairos_config, missing_worker_job, now)
+
+    let expected_now = test_db.to_postgres_precision(now)
+
+    assert_discarded(decode_failed, expected_now, "payload mismatch")
+    assert_discarded(missing_worker, expected_now, "worker not configured")
+  })
+}
+
+pub fn run_claimed_records_crashes_and_exhausted_retries_as_discarded_test() {
+  test_db.with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let crashing_contract = crashing_worker("workers.crash")
+    let exhausted_retry_contract =
+      result_worker("workers.exhausted", worker.Retry("retry later"))
+    let kairos_config =
+      build_config(connection, [
+        worker.register(crashing_contract),
+        worker.register(exhausted_retry_contract),
+      ])
+
+    let crashing_job = enqueue_and_claim(kairos_config, crashing_contract, now)
+    let exhausted_job =
+      enqueue_and_claim_with_attempts(
+        kairos_config,
+        exhausted_retry_contract,
+        1,
+        now,
+      )
+
+    let crashed = run_claimed(kairos_config, crashing_job, now)
+    let exhausted = run_claimed(kairos_config, exhausted_job, now)
+
+    let expected_now = test_db.to_postgres_precision(now)
+
+    assert_retryable(crashed, expected_now, "kind=crash", "worker crashed")
+    assert_discarded(exhausted, expected_now, "retry later")
+  })
+}
+
+fn build_config(
+  connection: pog.Connection,
+  registered_workers: List(worker.RegisteredWorker),
+) -> config.Config {
+  let assert Ok(default_queue) =
+    queue.new(name: "default", concurrency: 10, poll_interval_ms: 1000)
+  let assert Ok(kairos_config) =
+    config.new(
+      connection: connection,
+      queues: [default_queue],
+      workers: registered_workers,
+    )
+  kairos_config
+}
+
+fn enqueue_and_run_claimed(
+  kairos_config: config.Config,
+  contract: worker.Worker(ExampleArgs),
+  now: timestamp.Timestamp,
+) -> job_store.PersistedJob {
+  let claimed = enqueue_and_claim(kairos_config, contract, now)
+  run_claimed(kairos_config, claimed, now)
+}
+
+fn run_claimed(
+  kairos_config: config.Config,
+  claimed_job: job_store.PersistedJob,
+  now: timestamp.Timestamp,
+) -> job_store.PersistedJob {
+  let assert Ok(finished) =
+    job_runner.run_claimed(kairos_config, claimed_job, now)
+  finished
+}
+
+fn enqueue_and_claim(
+  kairos_config: config.Config,
+  contract: worker.Worker(ExampleArgs),
+  now: timestamp.Timestamp,
+) -> job_store.PersistedJob {
+  enqueue_and_claim_with_attempts(kairos_config, contract, 3, now)
+}
+
+fn enqueue_and_claim_with_attempts(
+  kairos_config: config.Config,
+  contract: worker.Worker(ExampleArgs),
+  max_attempts: Int,
+  _now: timestamp.Timestamp,
+) -> job_store.PersistedJob {
+  let args = ExampleArgs(name: worker.name(contract))
+  let assert Ok(custom_options) =
+    job.with_max_attempts(worker.default_options(contract), max_attempts)
+  let assert Ok(_) =
+    kairos.enqueue_with(kairos_config, contract, args, custom_options)
+  let claim_now = timestamp.system_time()
+  let assert Ok([claimed]) =
+    job_store.claim_available(
+      config.connection(kairos_config),
+      "default",
+      claim_now,
+      1,
+    )
+  claimed
+}
+
+fn insert_executing_job(
+  connection: pog.Connection,
+  worker_name worker_name: String,
+  payload payload: String,
+  max_attempts max_attempts: Int,
+  attempt attempt: Int,
+  attempted_at attempted_at: timestamp.Timestamp,
+) -> job_store.PersistedJob {
+  let assert Ok(inserted) =
+    job_store.insert(
+      connection,
+      job_store.JobInsert(
+        worker_name: worker_name,
+        payload: payload,
+        state: job.Executing,
+        queue_name: "default",
+        priority: 0,
+        attempt: attempt,
+        max_attempts: max_attempts,
+        unique_key: None,
+        errors: [],
+        scheduled_at: attempted_at,
+        attempted_at: Some(attempted_at),
+        completed_at: None,
+        discarded_at: None,
+        cancelled_at: None,
+      ),
+    )
+  inserted
+}
+
+fn assert_retryable(
+  persisted_job: job_store.PersistedJob,
+  expected_now: timestamp.Timestamp,
+  expected_kind: String,
+  reason_substring: String,
+) -> Nil {
+  let job_store.PersistedJob(
+    state: state,
+    scheduled_at: scheduled_at,
+    errors: errors,
+    ..,
+  ) = persisted_job
+
+  assert state == job.Retryable
+  assert scheduled_at == expected_now
+  let assert [error] = errors
+  assert string.contains(error, expected_kind)
+  assert string.contains(error, reason_substring)
+}
+
+fn assert_discarded(
+  persisted_job: job_store.PersistedJob,
+  expected_now: timestamp.Timestamp,
+  reason_substring: String,
+) -> Nil {
+  let job_store.PersistedJob(
+    state: state,
+    discarded_at: discarded_at,
+    errors: errors,
+    ..,
+  ) = persisted_job
+
+  assert state == job.Discarded
+  assert discarded_at == Some(expected_now)
+  let assert [error] = errors
+  assert string.contains(error, reason_substring)
+}
+
+fn assert_cancelled(
+  persisted_job: job_store.PersistedJob,
+  expected_now: timestamp.Timestamp,
+  reason_substring: String,
+) -> Nil {
+  let job_store.PersistedJob(
+    state: state,
+    cancelled_at: cancelled_at,
+    errors: errors,
+    ..,
+  ) = persisted_job
+
+  assert state == job.Cancelled
+  assert cancelled_at == Some(expected_now)
+  let assert [error] = errors
+  assert string.contains(error, reason_substring)
+}
+
+fn result_worker(
+  name: String,
+  result: worker.PerformResult,
+) -> worker.Worker(ExampleArgs) {
+  worker.new(
+    name,
+    fn(args) {
+      let ExampleArgs(name:) = args
+      name
+    },
+    fn(payload) { Ok(ExampleArgs(name: payload)) },
+    fn(_args) { result },
+    job.default_enqueue_options(),
+  )
+}
+
+fn decode_failure_worker(name: String) -> worker.Worker(ExampleArgs) {
+  worker.new(
+    name,
+    fn(args) {
+      let ExampleArgs(name:) = args
+      name
+    },
+    fn(_payload) { Error(worker.DecodeError("payload mismatch")) },
+    fn(_args) { worker.Success },
+    job.default_enqueue_options(),
+  )
+}
+
+fn crashing_worker(name: String) -> worker.Worker(ExampleArgs) {
+  worker.new(
+    name,
+    fn(args) {
+      let ExampleArgs(name:) = args
+      name
+    },
+    fn(payload) { Ok(ExampleArgs(name: payload)) },
+    fn(_args) { panic as "worker crashed" },
+    job.default_enqueue_options(),
+  )
+}

--- a/test/kairos/job_runner_test.gleam
+++ b/test/kairos/job_runner_test.gleam
@@ -58,12 +58,13 @@ pub fn run_claimed_persists_retry_discard_and_cancel_outcomes_test() {
       result_worker("workers.retry", worker.Retry("retry later"))
     let kairos_config =
       build_config(connection, [worker.register(retry_contract)])
-    let retried = enqueue_and_run_claimed(kairos_config, retry_contract, now)
+    let claimed = enqueue_and_claim(kairos_config, retry_contract, now)
+    let retried = run_claimed(kairos_config, claimed, now)
     let job_store.PersistedJob(id: retried_id, ..) = retried
     let assert Ok(Some(stored_retried)) =
       job_store.fetch(connection, retried_id)
     let expected_retry_at =
-      retried
+      claimed
       |> job_runner.retry_scheduled_at(now)
       |> test_db.to_postgres_precision
 
@@ -189,7 +190,7 @@ pub fn run_claimed_records_crashes_and_exhausted_retries_as_discarded_test() {
 
     let expected_now = test_db.to_postgres_precision(now)
     let expected_retry_at =
-      crashed
+      crashing_job
       |> job_runner.retry_scheduled_at(now)
       |> test_db.to_postgres_precision
 
@@ -226,7 +227,7 @@ pub fn run_claimed_appends_retry_history_test() {
     let assert Ok(Some(stored_retried)) =
       job_store.fetch(connection, retried_id)
     let expected_retry_at =
-      retried
+      claimed_job
       |> job_runner.retry_scheduled_at(now)
       |> test_db.to_postgres_precision
     let job_store.PersistedJob(errors: errors, ..) = stored_retried

--- a/test/kairos/job_runner_test.gleam
+++ b/test/kairos/job_runner_test.gleam
@@ -1,3 +1,4 @@
+import gleam/list
 import gleam/option.{None, Some}
 import gleam/string
 import gleam/time/timestamp
@@ -57,9 +58,20 @@ pub fn run_claimed_persists_retry_discard_and_cancel_outcomes_test() {
     let kairos_config =
       build_config(connection, [worker.register(retry_contract)])
     let retried = enqueue_and_run_claimed(kairos_config, retry_contract, now)
-    let expected_now = test_db.to_postgres_precision(now)
+    let job_store.PersistedJob(id: retried_id, ..) = retried
+    let assert Ok(Some(stored_retried)) =
+      job_store.fetch(connection, retried_id)
+    let expected_retry_at =
+      retried
+      |> job_runner.retry_scheduled_at(now)
+      |> test_db.to_postgres_precision
 
-    assert_retryable(retried, expected_now, "kind=retry", "retry later")
+    assert_retryable(
+      stored_retried,
+      expected_retry_at,
+      "kind=retry",
+      "retry later",
+    )
   })
 }
 
@@ -72,9 +84,12 @@ pub fn run_claimed_persists_discard_outcome_test() {
       build_config(connection, [worker.register(discard_contract)])
     let discarded =
       enqueue_and_run_claimed(kairos_config, discard_contract, now)
+    let job_store.PersistedJob(id: discarded_id, ..) = discarded
+    let assert Ok(Some(stored_discarded)) =
+      job_store.fetch(connection, discarded_id)
 
     let expected_now = test_db.to_postgres_precision(now)
-    assert_discarded(discarded, expected_now, "discard permanently")
+    assert_discarded(stored_discarded, expected_now, "discard permanently")
   })
 }
 
@@ -86,9 +101,12 @@ pub fn run_claimed_persists_cancel_outcome_test() {
     let kairos_config =
       build_config(connection, [worker.register(cancel_contract)])
     let cancelled = enqueue_and_run_claimed(kairos_config, cancel_contract, now)
+    let job_store.PersistedJob(id: cancelled_id, ..) = cancelled
+    let assert Ok(Some(stored_cancelled)) =
+      job_store.fetch(connection, cancelled_id)
 
     let expected_now = test_db.to_postgres_precision(now)
-    assert_cancelled(cancelled, expected_now, "cancel execution")
+    assert_cancelled(stored_cancelled, expected_now, "cancel execution")
   })
 }
 
@@ -120,11 +138,21 @@ pub fn run_claimed_discards_decode_failures_and_missing_workers_test() {
 
     let decode_failed = run_claimed(kairos_config, malformed_job, now)
     let missing_worker = run_claimed(kairos_config, missing_worker_job, now)
+    let job_store.PersistedJob(id: decode_failed_id, ..) = decode_failed
+    let job_store.PersistedJob(id: missing_worker_id, ..) = missing_worker
+    let assert Ok(Some(stored_decode_failed)) =
+      job_store.fetch(connection, decode_failed_id)
+    let assert Ok(Some(stored_missing_worker)) =
+      job_store.fetch(connection, missing_worker_id)
 
     let expected_now = test_db.to_postgres_precision(now)
 
-    assert_discarded(decode_failed, expected_now, "payload mismatch")
-    assert_discarded(missing_worker, expected_now, "worker not configured")
+    assert_discarded(stored_decode_failed, expected_now, "payload mismatch")
+    assert_discarded(
+      stored_missing_worker,
+      expected_now,
+      "worker not configured",
+    )
   })
 }
 
@@ -151,11 +179,66 @@ pub fn run_claimed_records_crashes_and_exhausted_retries_as_discarded_test() {
 
     let crashed = run_claimed(kairos_config, crashing_job, now)
     let exhausted = run_claimed(kairos_config, exhausted_job, now)
+    let job_store.PersistedJob(id: crashed_id, ..) = crashed
+    let job_store.PersistedJob(id: exhausted_id, ..) = exhausted
+    let assert Ok(Some(stored_crashed)) =
+      job_store.fetch(connection, crashed_id)
+    let assert Ok(Some(stored_exhausted)) =
+      job_store.fetch(connection, exhausted_id)
 
     let expected_now = test_db.to_postgres_precision(now)
+    let expected_retry_at =
+      crashed
+      |> job_runner.retry_scheduled_at(now)
+      |> test_db.to_postgres_precision
 
-    assert_retryable(crashed, expected_now, "kind=crash", "worker crashed")
-    assert_discarded(exhausted, expected_now, "retry later")
+    assert_retryable(
+      stored_crashed,
+      expected_retry_at,
+      "kind=crash",
+      "worker crashed",
+    )
+    assert_discarded(stored_exhausted, expected_now, "retry later")
+  })
+}
+
+pub fn run_claimed_appends_retry_history_test() {
+  test_db.with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let retry_contract =
+      result_worker("workers.retry-history", worker.Retry("retry later"))
+    let kairos_config =
+      build_config(connection, [worker.register(retry_contract)])
+    let claimed_job =
+      insert_executing_job_with_errors(
+        connection,
+        worker_name: "workers.retry-history",
+        payload: "kairos",
+        max_attempts: 4,
+        attempt: 2,
+        attempted_at: now,
+        errors: ["kind=retry attempt=1 reason=prior failure"],
+      )
+
+    let retried = run_claimed(kairos_config, claimed_job, now)
+    let job_store.PersistedJob(id: retried_id, ..) = retried
+    let assert Ok(Some(stored_retried)) =
+      job_store.fetch(connection, retried_id)
+    let expected_retry_at =
+      retried
+      |> job_runner.retry_scheduled_at(now)
+      |> test_db.to_postgres_precision
+    let job_store.PersistedJob(errors: errors, ..) = stored_retried
+
+    assert_retryable(
+      stored_retried,
+      expected_retry_at,
+      "kind=retry",
+      "retry later",
+    )
+    let assert [prior_error, appended_error] = errors
+    assert string.contains(prior_error, "prior failure")
+    assert string.contains(appended_error, "retry later")
   })
 }
 
@@ -231,6 +314,26 @@ fn insert_executing_job(
   attempt attempt: Int,
   attempted_at attempted_at: timestamp.Timestamp,
 ) -> job_store.PersistedJob {
+  insert_executing_job_with_errors(
+    connection,
+    worker_name: worker_name,
+    payload: payload,
+    max_attempts: max_attempts,
+    attempt: attempt,
+    attempted_at: attempted_at,
+    errors: [],
+  )
+}
+
+fn insert_executing_job_with_errors(
+  connection: pog.Connection,
+  worker_name worker_name: String,
+  payload payload: String,
+  max_attempts max_attempts: Int,
+  attempt attempt: Int,
+  attempted_at attempted_at: timestamp.Timestamp,
+  errors errors: List(String),
+) -> job_store.PersistedJob {
   let assert Ok(inserted) =
     job_store.insert(
       connection,
@@ -243,7 +346,7 @@ fn insert_executing_job(
         attempt: attempt,
         max_attempts: max_attempts,
         unique_key: None,
-        errors: [],
+        errors: errors,
         scheduled_at: attempted_at,
         attempted_at: Some(attempted_at),
         completed_at: None,
@@ -256,7 +359,7 @@ fn insert_executing_job(
 
 fn assert_retryable(
   persisted_job: job_store.PersistedJob,
-  expected_now: timestamp.Timestamp,
+  expected_scheduled_at: timestamp.Timestamp,
   expected_kind: String,
   reason_substring: String,
 ) -> Nil {
@@ -268,8 +371,8 @@ fn assert_retryable(
   ) = persisted_job
 
   assert state == job.Retryable
-  assert scheduled_at == expected_now
-  let assert [error] = errors
+  assert scheduled_at == expected_scheduled_at
+  let assert [error, ..] = list.reverse(errors)
   assert string.contains(error, expected_kind)
   assert string.contains(error, reason_substring)
 }

--- a/test/kairos/queue_dispatcher_test.gleam
+++ b/test/kairos/queue_dispatcher_test.gleam
@@ -1,16 +1,20 @@
 import gleam/erlang/process
+import gleam/list
 import gleam/option.{Some}
+import gleam/string
 import gleam/time/timestamp
 import gleeunit
 import kairos
 import kairos/config
 import kairos/job
+import kairos/job_runner
 import kairos/postgres/job_store
 import kairos/postgres/test_db
 import kairos/queue
 import kairos/queue_dispatcher
 import kairos/supervision
 import kairos/worker
+import pog
 
 type ExampleArgs {
   ExampleArgs(name: String)
@@ -39,12 +43,8 @@ pub fn dispatch_claims_jobs_and_starts_supervised_runners_test() {
     let assert Ok(started_runner_pids) =
       queue_dispatcher.dispatch(kairos_config, default_queue, started.data, now)
 
-    let assert [runner_pid] = started_runner_pids
-    assert process.is_alive(runner_pid)
-
-    process.sleep(50)
-
-    let assert Ok(Some(stored)) = job_store.fetch(connection, id)
+    let assert [_runner_pid] = started_runner_pids
+    let stored = wait_for_job(connection, id, 20)
     let job_store.PersistedJob(state: state, completed_at: completed_at, ..) =
       stored
 
@@ -59,15 +59,185 @@ pub fn dispatch_claims_jobs_and_starts_supervised_runners_test() {
   })
 }
 
+pub fn dispatch_persists_retry_discard_and_cancel_outcomes_test() {
+  test_db.with_database(fn(connection) {
+    let assert Ok(default_queue) =
+      queue.new(name: "default", concurrency: 3, poll_interval_ms: 1000)
+    let retry_worker =
+      result_worker("workers.retry", worker.Retry("retry later"))
+    let discard_worker =
+      result_worker("workers.discard", worker.Discard("discard permanently"))
+    let cancel_worker =
+      result_worker("workers.cancel", worker.Cancel("cancel execution"))
+    let assert Ok(kairos_config) =
+      config.new(connection: connection, queues: [default_queue], workers: [
+        worker.register(retry_worker),
+        worker.register(discard_worker),
+        worker.register(cancel_worker),
+      ])
+    let assert Ok(started) = kairos.start(kairos_config)
+
+    let assert Ok(retried) =
+      kairos.enqueue(kairos_config, retry_worker, ExampleArgs(name: "retry"))
+    let assert Ok(discarded) =
+      kairos.enqueue(
+        kairos_config,
+        discard_worker,
+        ExampleArgs(name: "discard"),
+      )
+    let assert Ok(cancelled) =
+      kairos.enqueue(kairos_config, cancel_worker, ExampleArgs(name: "cancel"))
+    let now = timestamp.system_time()
+
+    let assert Ok(started_runner_pids) =
+      queue_dispatcher.dispatch(kairos_config, default_queue, started.data, now)
+    assert list.length(started_runner_pids) == 3
+
+    let job.EnqueuedJob(id: retried_id, ..) = retried
+    let job.EnqueuedJob(id: discarded_id, ..) = discarded
+    let job.EnqueuedJob(id: cancelled_id, ..) = cancelled
+
+    let stored_retried = wait_for_job(connection, retried_id, 20)
+    let stored_discarded = wait_for_job(connection, discarded_id, 20)
+    let stored_cancelled = wait_for_job(connection, cancelled_id, 20)
+
+    let expected_retry_at =
+      stored_retried
+      |> job_runner.retry_scheduled_at(now)
+      |> test_db.to_postgres_precision
+    let expected_now = test_db.to_postgres_precision(now)
+
+    assert_retryable(
+      stored_retried,
+      expected_retry_at,
+      "kind=retry",
+      "retry later",
+    )
+    assert_discarded(stored_discarded, expected_now, "discard permanently")
+    assert_cancelled(stored_cancelled, expected_now, "cancel execution")
+
+    process.send_exit(started.pid)
+  })
+}
+
+pub fn dispatch_returns_claim_failed_for_invalid_connection_test() {
+  test_db.with_database(fn(connection) {
+    let contract = success_worker()
+    let assert Ok(default_queue) =
+      queue.new(name: "default", concurrency: 1, poll_interval_ms: 1000)
+    let assert Ok(kairos_config) =
+      config.new(connection: connection, queues: [default_queue], workers: [
+        worker.register(contract),
+      ])
+    let assert Ok(started) = kairos.start(kairos_config)
+    let assert Ok(_) =
+      pog.query("DROP TABLE kairos_jobs") |> pog.execute(connection)
+
+    let assert Error(queue_dispatcher.ClaimFailed(job_store.QueryFailed(_))) =
+      queue_dispatcher.dispatch(
+        kairos_config,
+        default_queue,
+        started.data,
+        timestamp.system_time(),
+      )
+
+    process.send_exit(started.pid)
+  })
+}
+
 fn success_worker() -> worker.Worker(ExampleArgs) {
+  result_worker("workers.success", worker.Success)
+}
+
+fn result_worker(
+  name: String,
+  result: worker.PerformResult,
+) -> worker.Worker(ExampleArgs) {
   worker.new(
-    "workers.success",
+    name,
     fn(args) {
       let ExampleArgs(name:) = args
       name
     },
     fn(payload) { Ok(ExampleArgs(name: payload)) },
-    fn(_args) { worker.Success },
+    fn(_args) { result },
     job.default_enqueue_options(),
   )
+}
+
+fn wait_for_job(
+  connection: pog.Connection,
+  id: String,
+  remaining_attempts: Int,
+) -> job_store.PersistedJob {
+  let assert Ok(Some(stored)) = job_store.fetch(connection, id)
+  let job_store.PersistedJob(state:, ..) = stored
+
+  case state, remaining_attempts {
+    job.Completed, _ -> stored
+    job.Retryable, _ -> stored
+    job.Discarded, _ -> stored
+    job.Cancelled, _ -> stored
+    _, 0 -> stored
+    _, _ -> {
+      process.sleep(25)
+      wait_for_job(connection, id, remaining_attempts - 1)
+    }
+  }
+}
+
+fn assert_retryable(
+  persisted_job: job_store.PersistedJob,
+  expected_scheduled_at: timestamp.Timestamp,
+  expected_kind: String,
+  reason_substring: String,
+) -> Nil {
+  let job_store.PersistedJob(
+    state: state,
+    scheduled_at: scheduled_at,
+    errors: errors,
+    ..,
+  ) = persisted_job
+
+  assert state == job.Retryable
+  assert scheduled_at == expected_scheduled_at
+  let assert [error] = errors
+  assert string.contains(error, expected_kind)
+  assert string.contains(error, reason_substring)
+}
+
+fn assert_discarded(
+  persisted_job: job_store.PersistedJob,
+  expected_now: timestamp.Timestamp,
+  reason_substring: String,
+) -> Nil {
+  let job_store.PersistedJob(
+    state: state,
+    discarded_at: discarded_at,
+    errors: errors,
+    ..,
+  ) = persisted_job
+
+  assert state == job.Discarded
+  assert discarded_at == Some(expected_now)
+  let assert [error] = errors
+  assert string.contains(error, reason_substring)
+}
+
+fn assert_cancelled(
+  persisted_job: job_store.PersistedJob,
+  expected_now: timestamp.Timestamp,
+  reason_substring: String,
+) -> Nil {
+  let job_store.PersistedJob(
+    state: state,
+    cancelled_at: cancelled_at,
+    errors: errors,
+    ..,
+  ) = persisted_job
+
+  assert state == job.Cancelled
+  assert cancelled_at == Some(expected_now)
+  let assert [error] = errors
+  assert string.contains(error, reason_substring)
 }

--- a/test/kairos/queue_dispatcher_test.gleam
+++ b/test/kairos/queue_dispatcher_test.gleam
@@ -1,0 +1,73 @@
+import gleam/erlang/process
+import gleam/option.{Some}
+import gleam/time/timestamp
+import gleeunit
+import kairos
+import kairos/config
+import kairos/job
+import kairos/postgres/job_store
+import kairos/postgres/test_db
+import kairos/queue
+import kairos/queue_dispatcher
+import kairos/supervision
+import kairos/worker
+
+type ExampleArgs {
+  ExampleArgs(name: String)
+}
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+pub fn dispatch_claims_jobs_and_starts_supervised_runners_test() {
+  test_db.with_database(fn(connection) {
+    let contract = success_worker()
+    let assert Ok(default_queue) =
+      queue.new(name: "default", concurrency: 2, poll_interval_ms: 1000)
+    let assert Ok(kairos_config) =
+      config.new(connection: connection, queues: [default_queue], workers: [
+        worker.register(contract),
+      ])
+    let assert Ok(started) = kairos.start(kairos_config)
+
+    let args = ExampleArgs(name: "kairos")
+    let assert Ok(enqueued) = kairos.enqueue(kairos_config, contract, args)
+    let job.EnqueuedJob(id: id, ..) = enqueued
+    let now = timestamp.system_time()
+
+    let assert Ok(started_runner_pids) =
+      queue_dispatcher.dispatch(kairos_config, default_queue, started.data, now)
+
+    let assert [runner_pid] = started_runner_pids
+    assert process.is_alive(runner_pid)
+
+    process.sleep(50)
+
+    let assert Ok(Some(stored)) = job_store.fetch(connection, id)
+    let job_store.PersistedJob(state: state, completed_at: completed_at, ..) =
+      stored
+
+    assert state == job.Completed
+    assert completed_at == Some(test_db.to_postgres_precision(now))
+
+    let assert Ok(runner_supervisor_pid) =
+      supervision.queue_runner_supervisor_pid(started.data, "default")
+    assert process.is_alive(runner_supervisor_pid)
+
+    process.send_exit(started.pid)
+  })
+}
+
+fn success_worker() -> worker.Worker(ExampleArgs) {
+  worker.new(
+    "workers.success",
+    fn(args) {
+      let ExampleArgs(name:) = args
+      name
+    },
+    fn(payload) { Ok(ExampleArgs(name: payload)) },
+    fn(_args) { worker.Success },
+    job.default_enqueue_options(),
+  )
+}

--- a/test/kairos/queue_dispatcher_test.gleam
+++ b/test/kairos/queue_dispatcher_test.gleam
@@ -178,7 +178,7 @@ fn wait_for_job(
     job.Retryable, _ -> stored
     job.Discarded, _ -> stored
     job.Cancelled, _ -> stored
-    _, 0 -> stored
+    _, 0 -> panic as "timed out waiting for terminal job state"
     _, _ -> {
       process.sleep(25)
       wait_for_job(connection, id, remaining_attempts - 1)

--- a/test/kairos/supervision_test.gleam
+++ b/test/kairos/supervision_test.gleam
@@ -26,12 +26,15 @@ pub fn start_builds_queue_supervisors_and_stub_processes_test() {
     supervision.queue_supervisor_pid(runtime, "default")
   let assert Ok(default_runner_supervisor) =
     supervision.queue_runner_supervisor_pid(runtime, "default")
+  let assert Ok(mailers_runner_supervisor) =
+    supervision.queue_runner_supervisor_pid(runtime, "mailers")
   let assert Ok(default_poller) =
     supervision.queue_poller_pid(runtime, "default")
 
   assert process.is_alive(root_pid)
   assert process.is_alive(default_supervisor)
   assert process.is_alive(default_runner_supervisor)
+  assert process.is_alive(mailers_runner_supervisor)
   assert process.is_alive(default_poller)
 
   process.send_exit(started.pid)

--- a/test/kairos/supervision_test.gleam
+++ b/test/kairos/supervision_test.gleam
@@ -24,14 +24,14 @@ pub fn start_builds_queue_supervisors_and_stub_processes_test() {
   let assert Ok(root_pid) = supervision.root_pid(runtime)
   let assert Ok(default_supervisor) =
     supervision.queue_supervisor_pid(runtime, "default")
-  let assert Ok(default_worker) =
-    supervision.queue_worker_pid(runtime, "default")
+  let assert Ok(default_runner_supervisor) =
+    supervision.queue_runner_supervisor_pid(runtime, "default")
   let assert Ok(default_poller) =
     supervision.queue_poller_pid(runtime, "default")
 
   assert process.is_alive(root_pid)
   assert process.is_alive(default_supervisor)
-  assert process.is_alive(default_worker)
+  assert process.is_alive(default_runner_supervisor)
   assert process.is_alive(default_poller)
 
   process.send_exit(started.pid)
@@ -56,7 +56,11 @@ fn sample_config() -> Result(config.Config, config.ConfigError) {
   let assert Ok(mailers_queue) =
     queue.new(name: "mailers", concurrency: 3, poll_interval_ms: 2000)
 
-  config.new(connection: connection, queues: [default_queue, mailers_queue])
+  config.new(
+    connection: connection,
+    queues: [default_queue, mailers_queue],
+    workers: [],
+  )
 }
 
 fn test_connection() -> pog.Connection {

--- a/test/kairos/worker_test.gleam
+++ b/test/kairos/worker_test.gleam
@@ -1,3 +1,4 @@
+import gleam/string
 import gleeunit
 import kairos/job
 import kairos/worker
@@ -39,6 +40,31 @@ pub fn perform_result_variants_test() {
     == worker.Cancel("cancel execution")
 }
 
+pub fn registered_worker_executes_payload_test() {
+  let registered_success = worker.register(success_worker())
+  let registered_retry = worker.register(retry_worker())
+  let registered_discard = worker.register(discard_worker())
+  let registered_cancel = worker.register(cancel_worker())
+  let registered_decode_failure = worker.register(example_worker())
+  let registered_crashing = worker.register(crashing_worker())
+
+  assert worker.registered_name(registered_success) == "example"
+  assert worker.execute_payload(registered_success, "kairos")
+    == worker.Succeeded
+  assert worker.execute_payload(registered_retry, "kairos")
+    == worker.RetryRequested("retry later")
+  assert worker.execute_payload(registered_discard, "kairos")
+    == worker.DiscardRequested("discard permanently")
+  assert worker.execute_payload(registered_cancel, "kairos")
+    == worker.CancelRequested("cancel execution")
+  assert worker.execute_payload(registered_decode_failure, "")
+    == worker.DecodeFailed("payload cannot be empty")
+
+  let crashing_result = worker.execute_payload(registered_crashing, "kairos")
+  let assert worker.Crashed(message) = crashing_result
+  assert string.contains(message, "worker crashed")
+}
+
 fn example_worker() -> worker.Worker(ExampleArgs) {
   result_worker(worker.Success)
 }
@@ -57,6 +83,24 @@ fn discard_worker() -> worker.Worker(ExampleArgs) {
 
 fn cancel_worker() -> worker.Worker(ExampleArgs) {
   result_worker(worker.Cancel("cancel execution"))
+}
+
+fn crashing_worker() -> worker.Worker(ExampleArgs) {
+  worker.new(
+    "example",
+    fn(args) {
+      let ExampleArgs(name:) = args
+      name
+    },
+    fn(payload) {
+      case payload {
+        "" -> Error(worker.DecodeError("payload cannot be empty"))
+        _ -> Ok(ExampleArgs(name: payload))
+      }
+    },
+    fn(_args) { panic as "worker crashed" },
+    job.default_enqueue_options(),
+  )
 }
 
 fn result_worker(result: worker.PerformResult) -> worker.Worker(ExampleArgs) {


### PR DESCRIPTION
## Summary
- register typed workers in `config.Config` so the runtime can resolve worker modules by name
- add supervised job runners plus a queue dispatcher that claims jobs and starts runner children under each queue
- persist lifecycle outcomes for completed, retryable, discarded, and cancelled jobs with structured failure details
- add integration coverage for worker execution, lifecycle transitions, dispatcher startup, and supervision wiring

## Validation
- `gleam format`
- `gleam check`
- `gleam test`
- temporary sample app smoke test against PostgreSQL: `register -> start -> enqueue -> dispatch -> completed`

Closes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable worker registration and lookup for job handlers
  * Background job runner executing claimed jobs, mapping outcomes (complete/retry/discard/cancel) and scheduling retries with backoff
  * Queue dispatcher that claims jobs and starts supervised runner processes
  * Persistent job state transitions with timestamps and appended error history

* **Reliability**
  * Improved failure handling, normalized failure reasons, and safer recovery paths

* **Tests**
  * Expanded tests for worker execution, runner behavior, dispatch, persistence, and supervision

* **Chores**
  * Added dependency for exception handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->