### PR TITLE
Add configurable retry backoff

### DIFF
--- a/src/kairos/backoff.gleam
+++ b/src/kairos/backoff.gleam
@@ -1,0 +1,98 @@
+import gleam/float
+import gleam/int
+
+pub opaque type Policy {
+  Policy(apply: fn(Context) -> Int)
+}
+
+pub opaque type Context {
+  Context(
+    attempt: Int,
+    max_attempts: Int,
+    worker_name: String,
+    queue_name: String,
+    error: String,
+  )
+}
+
+pub fn new_context(
+  attempt attempt: Int,
+  max_attempts max_attempts: Int,
+  worker_name worker_name: String,
+  queue_name queue_name: String,
+  error error: String,
+) -> Context {
+  Context(
+    attempt: attempt,
+    max_attempts: max_attempts,
+    worker_name: worker_name,
+    queue_name: queue_name,
+    error: error,
+  )
+}
+
+pub fn attempt(context: Context) -> Int {
+  let Context(attempt:, ..) = context
+  attempt
+}
+
+pub fn max_attempts(context: Context) -> Int {
+  let Context(max_attempts:, ..) = context
+  max_attempts
+}
+
+pub fn worker_name(context: Context) -> String {
+  let Context(worker_name:, ..) = context
+  worker_name
+}
+
+pub fn queue_name(context: Context) -> String {
+  let Context(queue_name:, ..) = context
+  queue_name
+}
+
+pub fn error(context: Context) -> String {
+  let Context(error:, ..) = context
+  error
+}
+
+pub fn default_policy() -> Policy {
+  custom_policy(default_seconds)
+}
+
+pub fn constant_policy(seconds: Int) -> Policy {
+  custom_policy(fn(_) { seconds })
+}
+
+pub fn custom_policy(apply: fn(Context) -> Int) -> Policy {
+  Policy(fn(context) {
+    let seconds = apply(context)
+    int.max(seconds, 0)
+  })
+}
+
+pub fn seconds(policy: Policy, context: Context) -> Int {
+  let Policy(apply:) = policy
+  apply(context)
+}
+
+fn default_seconds(context: Context) -> Int {
+  let clamped_attempt = case max_attempts(context) <= 20 {
+    True -> attempt(context)
+    False ->
+      float.round(
+        int.to_float(attempt(context))
+        /. int.to_float(max_attempts(context))
+        *. 20.0,
+      )
+  }
+
+  15 + pow2(int.min(clamped_attempt, 20))
+}
+
+fn pow2(exponent: Int) -> Int {
+  case exponent <= 0 {
+    True -> 1
+    False -> 2 * pow2(exponent - 1)
+  }
+}

--- a/src/kairos/job_runner.gleam
+++ b/src/kairos/job_runner.gleam
@@ -1,5 +1,4 @@
 import gleam/erlang/process
-import gleam/float
 import gleam/int
 import gleam/io
 import gleam/option.{None, Some}
@@ -7,6 +6,7 @@ import gleam/otp/actor
 import gleam/string
 import gleam/time/duration
 import gleam/time/timestamp
+import kairos/backoff
 import kairos/config
 import kairos/postgres/job_store
 import kairos/worker
@@ -60,6 +60,7 @@ fn run(
   let RunnerArg(config:, job: claimed_job, now:) = argument
   let transition = determine_transition(config, claimed_job)
   persist_or_recover_transition(
+    config,
     config.connection(config),
     claimed_job,
     now,
@@ -117,6 +118,7 @@ fn retry_or_discard(
 }
 
 fn persist_transition(
+  config: config.Config,
   connection: pog.Connection,
   claimed_job: job_store.PersistedJob,
   now: timestamp.Timestamp,
@@ -130,7 +132,7 @@ fn persist_transition(
       job_store.retry(
         connection,
         id,
-        retry_scheduled_at(claimed_job, now),
+        retry_scheduled_at(config, claimed_job, now, error),
         error,
       )
     MarkDiscarded(error) -> job_store.discard(connection, id, now, error)
@@ -139,15 +141,17 @@ fn persist_transition(
 }
 
 fn persist_or_recover_transition(
+  config: config.Config,
   connection: pog.Connection,
   claimed_job: job_store.PersistedJob,
   now: timestamp.Timestamp,
   transition: LifecycleTransition,
 ) -> Result(job_store.PersistedJob, job_store.StoreError) {
-  case persist_transition(connection, claimed_job, now, transition) {
+  case persist_transition(config, connection, claimed_job, now, transition) {
     Ok(persisted_job) -> Ok(persisted_job)
     Error(error) ->
       recover_transition_failure(
+        config,
         connection,
         claimed_job,
         now,
@@ -158,6 +162,7 @@ fn persist_or_recover_transition(
 }
 
 fn recover_transition_failure(
+  config: config.Config,
   connection: pog.Connection,
   claimed_job: job_store.PersistedJob,
   now: timestamp.Timestamp,
@@ -175,7 +180,7 @@ fn recover_transition_failure(
           job_store.retry(
             connection,
             id,
-            retry_scheduled_at(claimed_job, now),
+            retry_scheduled_at(config, claimed_job, now, recovery_error),
             recovery_error,
           )
         False -> Error(error)
@@ -186,13 +191,14 @@ fn recover_transition_failure(
 
 @internal
 pub fn retry_scheduled_at(
+  config: config.Config,
   claimed_job: job_store.PersistedJob,
   now: timestamp.Timestamp,
+  error: String,
 ) -> timestamp.Timestamp {
-  let job_store.PersistedJob(attempt:, max_attempts:, ..) = claimed_job
   timestamp.add(
     now,
-    duration.seconds(default_backoff_seconds(attempt, max_attempts)),
+    duration.seconds(retry_backoff_seconds(config, claimed_job, error)),
   )
 }
 
@@ -205,19 +211,38 @@ fn format_failure(kind: String, attempt: Int, reason: String) -> String {
   <> string.replace(reason, "\n", " ")
 }
 
-fn default_backoff_seconds(attempt: Int, max_attempts: Int) -> Int {
-  let clamped_attempt = case max_attempts <= 20 {
-    True -> attempt
-    False ->
-      float.round(int.to_float(attempt) /. int.to_float(max_attempts) *. 20.0)
-  }
+fn retry_backoff_seconds(
+  config: config.Config,
+  claimed_job: job_store.PersistedJob,
+  error: String,
+) -> Int {
+  let job_store.PersistedJob(worker_name: worker_name, ..) = claimed_job
+  let context = retry_context(claimed_job, error)
 
-  15 + pow2(int.min(clamped_attempt, 20))
+  case config.find_worker(config, worker_name) {
+    Some(registered_worker) ->
+      worker.backoff_seconds(registered_worker, context)
+    None -> backoff.seconds(backoff.default_policy(), context)
+  }
 }
 
-fn pow2(exponent: Int) -> Int {
-  case exponent <= 0 {
-    True -> 1
-    False -> 2 * pow2(exponent - 1)
-  }
+fn retry_context(
+  claimed_job: job_store.PersistedJob,
+  error: String,
+) -> backoff.Context {
+  let job_store.PersistedJob(
+    attempt: attempt,
+    max_attempts: max_attempts,
+    worker_name: worker_name,
+    queue_name: queue_name,
+    ..,
+  ) = claimed_job
+
+  backoff.new_context(
+    attempt: attempt,
+    max_attempts: max_attempts,
+    worker_name: worker_name,
+    queue_name: queue_name,
+    error: error,
+  )
 }

--- a/src/kairos/queue_dispatcher.gleam
+++ b/src/kairos/queue_dispatcher.gleam
@@ -99,16 +99,12 @@ fn release_claimed_jobs(
     [] -> Ok(Nil)
     [claimed_job, ..rest] -> {
       let job_store.PersistedJob(id:, attempt:, ..) = claimed_job
+      let failure_reason = format_dispatch_failure(attempt, start_error)
       use _ <- result.try(job_store.retry(
         connection,
         id,
-        job_runner.retry_scheduled_at(
-          config,
-          claimed_job,
-          now,
-          format_dispatch_failure(attempt, start_error),
-        ),
-        format_dispatch_failure(attempt, start_error),
+        job_runner.retry_scheduled_at(config, claimed_job, now, failure_reason),
+        failure_reason,
       ))
       release_claimed_jobs(config, connection, rest, now, start_error)
     }

--- a/src/kairos/queue_dispatcher.gleam
+++ b/src/kairos/queue_dispatcher.gleam
@@ -72,6 +72,7 @@ fn start_claimed_jobs(
         Error(start_error) ->
           case
             release_claimed_jobs(
+              config,
               config.connection(config),
               [claimed_job, ..rest],
               now,
@@ -88,6 +89,7 @@ fn start_claimed_jobs(
 }
 
 fn release_claimed_jobs(
+  config: config.Config,
   connection: pog.Connection,
   claimed_jobs: List(job_store.PersistedJob),
   now: timestamp.Timestamp,
@@ -100,10 +102,15 @@ fn release_claimed_jobs(
       use _ <- result.try(job_store.retry(
         connection,
         id,
-        job_runner.retry_scheduled_at(claimed_job, now),
+        job_runner.retry_scheduled_at(
+          config,
+          claimed_job,
+          now,
+          format_dispatch_failure(attempt, start_error),
+        ),
         format_dispatch_failure(attempt, start_error),
       ))
-      release_claimed_jobs(connection, rest, now, start_error)
+      release_claimed_jobs(config, connection, rest, now, start_error)
     }
   }
 }

--- a/src/kairos/worker.gleam
+++ b/src/kairos/worker.gleam
@@ -5,6 +5,7 @@
 
 import exception
 import gleam/string
+import kairos/backoff
 import kairos/job
 
 pub type DecodeError {
@@ -34,6 +35,7 @@ pub opaque type Worker(args) {
     decoder: fn(String) -> Result(args, DecodeError),
     performer: fn(args) -> PerformResult,
     default_options: job.EnqueueOptions,
+    backoff_policy: backoff.Policy,
   )
 }
 
@@ -41,6 +43,7 @@ pub opaque type RegisteredWorker {
   RegisteredWorker(
     name: String,
     execute_payload: fn(String) -> PayloadExecutionResult,
+    backoff_seconds: fn(backoff.Context) -> Int,
   )
 }
 
@@ -57,6 +60,7 @@ pub fn new(
     decoder: decoder,
     performer: performer,
     default_options: default_options,
+    backoff_policy: backoff.default_policy(),
   )
 }
 
@@ -68,6 +72,23 @@ pub fn name(contract: Worker(args)) -> String {
 pub fn default_options(contract: Worker(args)) -> job.EnqueueOptions {
   let Worker(default_options:, ..) = contract
   default_options
+}
+
+pub fn with_backoff(
+  contract: Worker(args),
+  policy: backoff.Policy,
+) -> Worker(args) {
+  let Worker(name:, encoder:, decoder:, performer:, default_options:, ..) =
+    contract
+
+  Worker(
+    name: name,
+    encoder: encoder,
+    decoder: decoder,
+    performer: performer,
+    default_options: default_options,
+    backoff_policy: policy,
+  )
 }
 
 /// Encodes worker arguments into a persisted payload string.
@@ -91,9 +112,13 @@ pub fn perform(contract: Worker(args), args: args) -> PerformResult {
 }
 
 pub fn register(contract: Worker(args)) -> RegisteredWorker {
-  RegisteredWorker(name: name(contract), execute_payload: fn(payload) {
-    run_payload(contract, payload)
-  })
+  let Worker(backoff_policy:, ..) = contract
+
+  RegisteredWorker(
+    name: name(contract),
+    execute_payload: fn(payload) { run_payload(contract, payload) },
+    backoff_seconds: fn(context) { backoff.seconds(backoff_policy, context) },
+  )
 }
 
 pub fn registered_name(registered_worker: RegisteredWorker) -> String {
@@ -108,6 +133,15 @@ pub fn execute_payload(
 ) -> PayloadExecutionResult {
   let RegisteredWorker(execute_payload:, ..) = registered_worker
   execute_payload(payload)
+}
+
+@internal
+pub fn backoff_seconds(
+  registered_worker: RegisteredWorker,
+  context: backoff.Context,
+) -> Int {
+  let RegisteredWorker(backoff_seconds:, ..) = registered_worker
+  backoff_seconds(context)
 }
 
 fn run_payload(

--- a/test/kairos/backoff_test.gleam
+++ b/test/kairos/backoff_test.gleam
@@ -1,0 +1,54 @@
+import gleam/string
+import gleeunit
+import kairos/backoff
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+pub fn default_policy_uses_exponential_backoff_test() {
+  let context =
+    backoff.new_context(
+      attempt: 3,
+      max_attempts: 20,
+      worker_name: "workers.example",
+      queue_name: "default",
+      error: "boom",
+    )
+
+  assert backoff.seconds(backoff.default_policy(), context) == 23
+}
+
+pub fn default_policy_clamps_large_attempt_ranges_test() {
+  let context =
+    backoff.new_context(
+      attempt: 40,
+      max_attempts: 100,
+      worker_name: "workers.example",
+      queue_name: "default",
+      error: "boom",
+    )
+
+  assert backoff.seconds(backoff.default_policy(), context) == 271
+}
+
+pub fn custom_policy_receives_typed_retry_context_test() {
+  let context =
+    backoff.new_context(
+      attempt: 4,
+      max_attempts: 9,
+      worker_name: "workers.mailers",
+      queue_name: "mailers",
+      error: "retry later",
+    )
+  let policy =
+    backoff.custom_policy(fn(context) {
+      backoff.attempt(context)
+      + backoff.max_attempts(context)
+      + string.length(backoff.worker_name(context))
+      + string.length(backoff.queue_name(context))
+      + string.length(backoff.error(context))
+    })
+
+  assert backoff.seconds(policy, context) == 46
+}

--- a/test/kairos/backoff_test.gleam
+++ b/test/kairos/backoff_test.gleam
@@ -19,6 +19,32 @@ pub fn default_policy_uses_exponential_backoff_test() {
   assert backoff.seconds(backoff.default_policy(), context) == 23
 }
 
+pub fn default_policy_handles_first_attempt_test() {
+  let context =
+    backoff.new_context(
+      attempt: 1,
+      max_attempts: 20,
+      worker_name: "workers.example",
+      queue_name: "default",
+      error: "boom",
+    )
+
+  assert backoff.seconds(backoff.default_policy(), context) == 17
+}
+
+pub fn default_policy_handles_single_attempt_jobs_test() {
+  let context =
+    backoff.new_context(
+      attempt: 1,
+      max_attempts: 1,
+      worker_name: "workers.example",
+      queue_name: "default",
+      error: "boom",
+    )
+
+  assert backoff.seconds(backoff.default_policy(), context) == 17
+}
+
 pub fn default_policy_clamps_large_attempt_ranges_test() {
   let context =
     backoff.new_context(

--- a/test/kairos/job_runner_test.gleam
+++ b/test/kairos/job_runner_test.gleam
@@ -2,9 +2,11 @@ import gleam/dynamic/decode
 import gleam/list
 import gleam/option.{None, Some}
 import gleam/string
+import gleam/time/duration
 import gleam/time/timestamp
 import gleeunit
 import kairos
+import kairos/backoff
 import kairos/config
 import kairos/job
 import kairos/job_runner
@@ -64,8 +66,40 @@ pub fn run_claimed_persists_retry_discard_and_cancel_outcomes_test() {
     let assert Ok(Some(stored_retried)) =
       job_store.fetch(connection, retried_id)
     let expected_retry_at =
-      claimed
-      |> job_runner.retry_scheduled_at(now)
+      job_runner.retry_scheduled_at(
+        kairos_config,
+        claimed,
+        now,
+        "kind=retry attempt=1 reason=retry later",
+      )
+      |> test_db.to_postgres_precision
+
+    assert_retryable(
+      stored_retried,
+      expected_retry_at,
+      "kind=retry",
+      "retry later",
+    )
+  })
+}
+
+pub fn run_claimed_uses_worker_backoff_policy_test() {
+  test_db.with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let retry_contract =
+      worker.with_backoff(
+        result_worker("workers.custom-retry", worker.Retry("retry later")),
+        backoff.custom_policy(fn(context) { backoff.attempt(context) * 60 }),
+      )
+    let kairos_config =
+      build_config(connection, [worker.register(retry_contract)])
+    let claimed = enqueue_and_claim(kairos_config, retry_contract, now)
+    let retried = run_claimed(kairos_config, claimed, now)
+    let job_store.PersistedJob(id: retried_id, ..) = retried
+    let assert Ok(Some(stored_retried)) =
+      job_store.fetch(connection, retried_id)
+    let expected_retry_at =
+      timestamp.add(now, duration.seconds(60))
       |> test_db.to_postgres_precision
 
     assert_retryable(
@@ -190,8 +224,12 @@ pub fn run_claimed_records_crashes_and_exhausted_retries_as_discarded_test() {
 
     let expected_now = test_db.to_postgres_precision(now)
     let expected_retry_at =
-      crashing_job
-      |> job_runner.retry_scheduled_at(now)
+      job_runner.retry_scheduled_at(
+        kairos_config,
+        crashing_job,
+        now,
+        "kind=crash attempt=1 reason=worker crashed",
+      )
       |> test_db.to_postgres_precision
 
     assert_retryable(
@@ -227,8 +265,12 @@ pub fn run_claimed_appends_retry_history_test() {
     let assert Ok(Some(stored_retried)) =
       job_store.fetch(connection, retried_id)
     let expected_retry_at =
-      claimed_job
-      |> job_runner.retry_scheduled_at(now)
+      job_runner.retry_scheduled_at(
+        kairos_config,
+        claimed_job,
+        now,
+        "kind=retry attempt=2 reason=retry later",
+      )
       |> test_db.to_postgres_precision
     let job_store.PersistedJob(errors: errors, ..) = stored_retried
 

--- a/test/kairos/queue_dispatcher_test.gleam
+++ b/test/kairos/queue_dispatcher_test.gleam
@@ -102,8 +102,12 @@ pub fn dispatch_persists_retry_discard_and_cancel_outcomes_test() {
     let stored_cancelled = wait_for_job(connection, cancelled_id, 20)
 
     let expected_retry_at =
-      stored_retried
-      |> job_runner.retry_scheduled_at(now)
+      job_runner.retry_scheduled_at(
+        kairos_config,
+        stored_retried,
+        now,
+        "kind=retry attempt=1 reason=retry later",
+      )
       |> test_db.to_postgres_precision
     let expected_now = test_db.to_postgres_precision(now)
 


### PR DESCRIPTION
## Summary

- add a public `kairos/backoff` module with typed retry context and configurable policies
- add `worker.with_backoff(...)` so retry scheduling stays worker-owned instead of hard-coded in the runner
- route runner and dispatcher retry scheduling through the configured backoff policy
- add coverage for default backoff behavior, custom policies, runner retry scheduling, and dispatcher retry outcomes

Closes #9.

## Validation

- `gleam format`
- `gleam check`
- `gleam test` (`44 passed, no failures`)
- `gleam run` in `/tmp/kairos_issue_9_smoke_app` (`sample app smoke test passed`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customizable backoff policy system for job retry scheduling.
  * Workers can specify per-worker retry delay policies (overrideable).
  * Default retry policy uses exponential backoff with clamping based on attempts.
  * Retry scheduling now factors worker identity, queue name, and error context.

* **Tests**
  * Added tests validating default and custom backoff behaviors and expected retry timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->