### PR TITLE
Add cancellation and stale job recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Typed background jobs for Gleam on the BEAM.
 
 </div>
 
-Kairos is an early-stage background job runner for Gleam on the BEAM. On `main` today it provides typed worker contracts, PostgreSQL-backed job persistence, queue configuration, public enqueue APIs, and atomic job claiming.
+Kairos is an early-stage background job runner for Gleam on the BEAM. On `main` today it provides typed worker contracts, PostgreSQL-backed job persistence, queue configuration, public enqueue APIs, atomic job claiming, supervised job dispatch, cancellation before execution, and stale execution recovery.
 
-Automatic worker execution, retry backoff, and recovery behavior are still being built, so expect the `0.x` API and supervision model to keep moving.
+Kairos still does not run an always-on queue loop by itself, so expect the `0.x` API and supervision model to keep moving while runtime automation fills in.
 
 ## Installation
 
@@ -33,8 +33,11 @@ Kairos on `main` currently supports:
 - configuring named queues and supervising Kairos inside a host app
 - enqueueing jobs with queue, priority, max-attempts, and schedule options
 - storing jobs in PostgreSQL and atomically claiming runnable jobs per queue
+- dispatching claimed jobs through supervised runners
+- cancelling queued jobs before execution
+- recovering stale `executing` jobs back into a runnable or terminal state
 
-Kairos on `main` does not yet run an always-on execution loop. Claiming is available now, but execution remains app-owned until the runtime layer lands.
+Kairos on `main` does not yet run an always-on execution loop. Dispatch and recovery are available now, but polling and continuous execution remain app-owned.
 
 ## Setup
 
@@ -70,7 +73,7 @@ pub fn kairos_child(
     queue.new(name: "default", concurrency: 10, poll_interval_ms: 1_000),
   )
   use kairos_config <- result.try(
-    config.new(connection: connection, queues: [default_queue]),
+    config.new(connection: connection, queues: [default_queue], workers: []),
   )
   Ok(kairos.supervised(kairos_config))
 }
@@ -117,27 +120,65 @@ pub fn enqueue_report(
 }
 ```
 
-## Claiming Jobs
+## Dispatching Jobs
 
-Kairos can already claim runnable jobs atomically from PostgreSQL. That is the current execution boundary on `main`:
+Kairos can claim runnable jobs atomically and dispatch them through supervised runners:
 
 ```gleam
 import gleam/time/timestamp
+import kairos
 import kairos/config
-import kairos/postgres/job_store
+import kairos/queue
+import kairos/queue_dispatcher
+import kairos/supervision
 
-pub fn claim_default_queue(
+pub fn dispatch_default_queue(
   kairos_config: config.Config,
-) -> List(job_store.PersistedJob) {
-  let assert Ok(claimed_jobs) =
-    job_store.claim_available(
-      config.connection(kairos_config),
-      "default",
+) -> Nil {
+  let assert Ok(default_queue) =
+    queue.new(name: "default", concurrency: 10, poll_interval_ms: 1_000)
+  let assert Ok(started) = kairos.start(kairos_config)
+  let runtime = started.data
+
+  let assert Ok(_runner_pids) =
+    queue_dispatcher.dispatch(
+      kairos_config,
+      default_queue,
+      runtime,
       timestamp.system_time(),
-      10,
     )
 
-  claimed_jobs
+  Nil
+}
+```
+
+## Cancellation And Recovery
+
+Kairos also exposes public helpers for cancelling queued jobs before they execute and for recovering stale `executing` jobs after interruption or restart:
+
+```gleam
+import gleam/time/duration
+import gleam/time/timestamp
+import kairos
+import kairos/config
+import kairos/supervision
+
+pub fn recover_default_queue(
+  kairos_config: config.Config,
+  runtime: supervision.Runtime,
+  job_id: String,
+) -> Nil {
+  let assert Ok(_) = kairos.cancel(kairos_config, job_id)
+
+  let assert Ok(_recovered_count) =
+    kairos.recover_stale(
+      runtime,
+      "default",
+      timestamp.system_time(),
+      duration.minutes(5),
+    )
+
+  Nil
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -134,11 +134,10 @@ import kairos/supervision
 
 pub fn dispatch_default_queue(
   kairos_config: config.Config,
+  runtime: supervision.Runtime,
 ) -> Nil {
   let assert Ok(default_queue) =
     queue.new(name: "default", concurrency: 10, poll_interval_ms: 1_000)
-  let assert Ok(started) = kairos.start(kairos_config)
-  let runtime = started.data
 
   let assert Ok(_runner_pids) =
     queue_dispatcher.dispatch(

--- a/src/kairos.gleam
+++ b/src/kairos.gleam
@@ -27,12 +27,14 @@ pub type CancelError {
   JobNotCancellable(job.JobState)
   CancelStoreQueryFailed
   CancelInvalidStoredState(String)
+  CancelUnexpectedStoredRowCount(expected: Int, actual: Int)
 }
 
 pub type RecoveryError {
   QueueRuntimeUnavailable(String)
   RecoveryStoreQueryFailed
   RecoveryInvalidStoredState(String)
+  RecoveryUnexpectedStoredRowCount(expected: Int, actual: Int)
 }
 
 pub fn package_name() -> String {
@@ -256,7 +258,8 @@ fn map_cancel_store_error(error: job_store.StoreError) -> CancelError {
   case error {
     job_store.QueryFailed(_) -> CancelStoreQueryFailed
     job_store.InvalidJobState(state) -> CancelInvalidStoredState(state)
-    job_store.UnexpectedRowCount(_, _) -> CancelStoreQueryFailed
+    job_store.UnexpectedRowCount(expected:, actual:) ->
+      CancelUnexpectedStoredRowCount(expected: expected, actual: actual)
   }
 }
 
@@ -264,6 +267,7 @@ fn map_recovery_store_error(error: job_store.StoreError) -> RecoveryError {
   case error {
     job_store.QueryFailed(_) -> RecoveryStoreQueryFailed
     job_store.InvalidJobState(state) -> RecoveryInvalidStoredState(state)
-    job_store.UnexpectedRowCount(_, _) -> RecoveryStoreQueryFailed
+    job_store.UnexpectedRowCount(expected:, actual:) ->
+      RecoveryUnexpectedStoredRowCount(expected: expected, actual: actual)
   }
 }

--- a/src/kairos.gleam
+++ b/src/kairos.gleam
@@ -1,3 +1,4 @@
+import gleam/erlang/process
 import gleam/int
 import gleam/list
 import gleam/option.{None, Some}
@@ -147,8 +148,30 @@ pub fn recover_stale(
     |> result.map_error(fn(_) { QueueRuntimeUnavailable(queue_name) })
   use reaper_name <- result.try(reaper_name)
 
-  queue_reaper.recover(reaper_name, now, stale_for)
-  |> result.map_error(map_recovery_store_error)
+  recover_stale_in_batches(reaper_name, now, stale_for, 0)
+}
+
+fn recover_stale_in_batches(
+  reaper_name: process.Name(queue_reaper.Message),
+  now: timestamp.Timestamp,
+  stale_for: duration.Duration,
+  recovered_count: Int,
+) -> Result(Int, RecoveryError) {
+  let recovered_in_batch =
+    queue_reaper.recover(reaper_name, now, stale_for)
+    |> result.map_error(map_recovery_store_error)
+  use recovered_in_batch <- result.try(recovered_in_batch)
+
+  case recovered_in_batch {
+    0 -> Ok(recovered_count)
+    _ ->
+      recover_stale_in_batches(
+        reaper_name,
+        now,
+        stale_for,
+        recovered_count + recovered_in_batch,
+      )
+  }
 }
 
 fn validate_queue(

--- a/src/kairos.gleam
+++ b/src/kairos.gleam
@@ -1,20 +1,38 @@
+import gleam/int
 import gleam/list
-import gleam/option.{None}
+import gleam/option.{None, Some}
 import gleam/otp/actor
 import gleam/otp/supervision.{type ChildSpecification}
+import gleam/result
+import gleam/time/duration
 import gleam/time/timestamp
 import kairos/config
 import kairos/job
 import kairos/postgres/job_store
 import kairos/queue
+import kairos/queue_reaper
 import kairos/supervision as kairos_supervision
 import kairos/worker
+import pog
 
 pub type EnqueueError {
   QueueNotConfigured(String)
   StoreQueryFailed
   UnexpectedStoredRowCount(expected: Int, actual: Int)
   InvalidStoredState(String)
+}
+
+pub type CancelError {
+  JobNotFound(String)
+  JobNotCancellable(job.JobState)
+  CancelStoreQueryFailed
+  CancelInvalidStoredState(String)
+}
+
+pub type RecoveryError {
+  QueueRuntimeUnavailable(String)
+  RecoveryStoreQueryFailed
+  RecoveryInvalidStoredState(String)
 }
 
 pub fn package_name() -> String {
@@ -76,6 +94,59 @@ pub fn enqueue_with(
       }
     }
   }
+}
+
+@internal
+pub fn cancel_at(
+  config: config.Config,
+  id: String,
+  now: timestamp.Timestamp,
+) -> Result(Nil, CancelError) {
+  pog.transaction(config.connection(config), fn(connection) {
+    let fetched =
+      job_store.fetch_for_update(connection, id)
+      |> result.map_error(map_cancel_store_error)
+    use fetched <- result.try(fetched)
+
+    case fetched {
+      None -> Error(JobNotFound(id))
+      Some(persisted_job) -> {
+        let job_store.PersistedJob(state:, attempt:, ..) = persisted_job
+
+        case can_cancel(state) {
+          True -> {
+            let error = cancel_error(attempt)
+            let cancelled =
+              job_store.cancel_before_execution(connection, id, now, error)
+              |> result.map_error(map_cancel_store_error)
+            use _ <- result.try(cancelled)
+            Ok(Nil)
+          }
+          False -> Error(JobNotCancellable(state))
+        }
+      }
+    }
+  })
+  |> map_cancel_transaction_error
+}
+
+pub fn cancel(config: config.Config, id: String) -> Result(Nil, CancelError) {
+  cancel_at(config, id, timestamp.system_time())
+}
+
+pub fn recover_stale(
+  runtime: kairos_supervision.Runtime,
+  queue_name: String,
+  now: timestamp.Timestamp,
+  stale_for: duration.Duration,
+) -> Result(Int, RecoveryError) {
+  let reaper_name =
+    kairos_supervision.queue_reaper_name(runtime, queue_name)
+    |> result.map_error(fn(_) { QueueRuntimeUnavailable(queue_name) })
+  use reaper_name <- result.try(reaper_name)
+
+  queue_reaper.recover(reaper_name, now, stale_for)
+  |> result.map_error(map_recovery_store_error)
 }
 
 fn validate_queue(
@@ -153,5 +224,46 @@ fn map_store_error(error: job_store.StoreError) -> EnqueueError {
     job_store.UnexpectedRowCount(expected:, actual:) ->
       UnexpectedStoredRowCount(expected: expected, actual: actual)
     job_store.InvalidJobState(state) -> InvalidStoredState(state)
+  }
+}
+
+fn can_cancel(state: job.JobState) -> Bool {
+  case state {
+    job.Pending -> True
+    job.Scheduled -> True
+    job.Retryable -> True
+    _ -> False
+  }
+}
+
+fn cancel_error(attempt: Int) -> String {
+  "kind=cancel attempt="
+  <> int.to_string(attempt)
+  <> " reason=cancelled before execution"
+}
+
+fn map_cancel_transaction_error(
+  result: Result(Nil, pog.TransactionError(CancelError)),
+) -> Result(Nil, CancelError) {
+  case result {
+    Ok(value) -> Ok(value)
+    Error(pog.TransactionQueryError(_)) -> Error(CancelStoreQueryFailed)
+    Error(pog.TransactionRolledBack(error)) -> Error(error)
+  }
+}
+
+fn map_cancel_store_error(error: job_store.StoreError) -> CancelError {
+  case error {
+    job_store.QueryFailed(_) -> CancelStoreQueryFailed
+    job_store.InvalidJobState(state) -> CancelInvalidStoredState(state)
+    job_store.UnexpectedRowCount(_, _) -> CancelStoreQueryFailed
+  }
+}
+
+fn map_recovery_store_error(error: job_store.StoreError) -> RecoveryError {
+  case error {
+    job_store.QueryFailed(_) -> RecoveryStoreQueryFailed
+    job_store.InvalidJobState(state) -> RecoveryInvalidStoredState(state)
+    job_store.UnexpectedRowCount(_, _) -> RecoveryStoreQueryFailed
   }
 }

--- a/src/kairos/postgres/job_store.gleam
+++ b/src/kairos/postgres/job_store.gleam
@@ -148,11 +148,13 @@ pub fn fetch_stale_executing(
   connection: db.Connection,
   queue_name: String,
   attempted_before: timestamp.Timestamp,
+  limit: Int,
 ) -> Result(List(PersistedJob), StoreError) {
   query.fetch_stale_executing()
   |> db.query
   |> db.parameter(db.text(queue_name))
   |> db.parameter(db.timestamp(attempted_before))
+  |> db.parameter(db.int(limit))
   |> db.returning(raw_job.decoder())
   |> db.execute(connection)
   |> map_many_row_result

--- a/src/kairos/postgres/job_store.gleam
+++ b/src/kairos/postgres/job_store.gleam
@@ -118,6 +118,18 @@ pub fn fetch(
   |> map_optional_row_result
 }
 
+pub fn fetch_for_update(
+  connection: db.Connection,
+  id: String,
+) -> Result(Option(PersistedJob), StoreError) {
+  query.fetch_for_update()
+  |> db.query
+  |> db.parameter(db.text(id))
+  |> db.returning(raw_job.decoder())
+  |> db.execute(connection)
+  |> map_optional_row_result
+}
+
 pub fn fetch_available(
   connection: db.Connection,
   now: timestamp.Timestamp,
@@ -127,6 +139,20 @@ pub fn fetch_available(
   |> db.query
   |> db.parameter(db.timestamp(now))
   |> db.parameter(db.int(limit))
+  |> db.returning(raw_job.decoder())
+  |> db.execute(connection)
+  |> map_many_row_result
+}
+
+pub fn fetch_stale_executing(
+  connection: db.Connection,
+  queue_name: String,
+  attempted_before: timestamp.Timestamp,
+) -> Result(List(PersistedJob), StoreError) {
+  query.fetch_stale_executing()
+  |> db.query
+  |> db.parameter(db.text(queue_name))
+  |> db.parameter(db.timestamp(attempted_before))
   |> db.returning(raw_job.decoder())
   |> db.execute(connection)
   |> map_many_row_result
@@ -201,6 +227,22 @@ pub fn cancel(
   error: String,
 ) -> Result(PersistedJob, StoreError) {
   query.cancel()
+  |> db.query
+  |> db.parameter(db.text(id))
+  |> db.parameter(db.timestamp(cancelled_at))
+  |> db.parameter(db.text(error))
+  |> db.returning(raw_job.decoder())
+  |> db.execute(connection)
+  |> map_single_row_result
+}
+
+pub fn cancel_before_execution(
+  connection: db.Connection,
+  id: String,
+  cancelled_at: timestamp.Timestamp,
+  error: String,
+) -> Result(PersistedJob, StoreError) {
+  query.cancel_before_execution()
   |> db.query
   |> db.parameter(db.text(id))
   |> db.parameter(db.timestamp(cancelled_at))

--- a/src/kairos/postgres/job_store/query.gleam
+++ b/src/kairos/postgres/job_store/query.gleam
@@ -82,6 +82,7 @@ pub fn fetch_stale_executing() -> String {
       AND attempted_at IS NOT NULL
       AND attempted_at <= $2
     ORDER BY attempted_at ASC, inserted_at ASC
+    LIMIT $3
     FOR UPDATE SKIP LOCKED
   )
   SELECT

--- a/src/kairos/postgres/job_store/query.gleam
+++ b/src/kairos/postgres/job_store/query.gleam
@@ -47,6 +47,17 @@ pub fn fetch() -> String {
 }
 
 @internal
+pub fn fetch_for_update() -> String {
+  "
+  SELECT
+  " <> selected_columns("kairos_jobs") <> "
+  FROM kairos_jobs
+  WHERE id = $1
+  FOR UPDATE
+  "
+}
+
+@internal
 pub fn fetch_available() -> String {
   "
   SELECT
@@ -57,6 +68,28 @@ pub fn fetch_available() -> String {
     AND attempt < max_attempts
   ORDER BY priority DESC, scheduled_at ASC, inserted_at ASC
   LIMIT $2
+  "
+}
+
+@internal
+pub fn fetch_stale_executing() -> String {
+  "
+  WITH stale AS (
+    SELECT id
+    FROM kairos_jobs
+    WHERE queue_name = $1
+      AND state = 'executing'
+      AND attempted_at IS NOT NULL
+      AND attempted_at <= $2
+    ORDER BY attempted_at ASC, inserted_at ASC
+    FOR UPDATE SKIP LOCKED
+  )
+  SELECT
+  " <> selected_columns("kairos_jobs") <> "
+  FROM kairos_jobs
+  INNER JOIN stale
+    ON kairos_jobs.id = stale.id
+  ORDER BY kairos_jobs.attempted_at ASC, kairos_jobs.inserted_at ASC
   "
 }
 
@@ -132,6 +165,19 @@ pub fn cancel() -> String {
     errors = array_append(kairos_jobs.errors, $3::TEXT)
   WHERE id = $1
     AND state = 'executing'
+  " <> returned_columns("kairos_jobs")
+}
+
+@internal
+pub fn cancel_before_execution() -> String {
+  "
+  UPDATE kairos_jobs
+  SET
+    state = 'cancelled',
+    cancelled_at = $2,
+    errors = array_append(kairos_jobs.errors, $3::TEXT)
+  WHERE id = $1
+    AND state IN ('pending', 'scheduled', 'retryable')
   " <> returned_columns("kairos_jobs")
 }
 

--- a/src/kairos/queue_reaper.gleam
+++ b/src/kairos/queue_reaper.gleam
@@ -67,13 +67,13 @@ pub fn recover(
 fn handle_message(state: State, message: Message) -> actor.Next(State, Message) {
   case message {
     Recover(now:, stale_for:, reply_with:) -> {
-      process.send(reply_with, recover_stale_jobs(state, now, stale_for))
+      process.send(reply_with, recover_stale_job_batch(state, now, stale_for))
       actor.continue(state)
     }
   }
 }
 
-fn recover_stale_jobs(
+fn recover_stale_job_batch(
   state: State,
   now: timestamp.Timestamp,
   stale_for: duration.Duration,
@@ -86,16 +86,15 @@ fn recover_stale_jobs(
       let attempted_before =
         timestamp.add(now, duration.milliseconds(-stale_for_ms))
 
-      recover_stale_jobs_in_batches(state, now, attempted_before, 0)
+      recover_stale_jobs_in_batch(state, now, attempted_before)
     }
   }
 }
 
-fn recover_stale_jobs_in_batches(
+fn recover_stale_jobs_in_batch(
   state: State,
   now: timestamp.Timestamp,
   attempted_before: timestamp.Timestamp,
-  recovered_count: Int,
 ) -> Result(Int, job_store.StoreError) {
   let State(config:, queue_name:) = state
 
@@ -112,18 +111,8 @@ fn recover_stale_jobs_in_batches(
       recover_jobs(connection, stale_jobs, now, 0)
     })
     |> map_transaction_error
-  use recovered_in_batch <- result.try(recovered_in_batch)
 
-  case recovered_in_batch {
-    0 -> Ok(recovered_count)
-    _ ->
-      recover_stale_jobs_in_batches(
-        state,
-        now,
-        attempted_before,
-        recovered_count + recovered_in_batch,
-      )
-  }
+  recovered_in_batch
 }
 
 fn recover_jobs(

--- a/src/kairos/queue_reaper.gleam
+++ b/src/kairos/queue_reaper.gleam
@@ -78,13 +78,17 @@ fn recover_stale_jobs(
   now: timestamp.Timestamp,
   stale_for: duration.Duration,
 ) -> Result(Int, job_store.StoreError) {
-  let attempted_before =
-    timestamp.add(
-      now,
-      duration.milliseconds(-duration.to_milliseconds(stale_for)),
-    )
+  let stale_for_ms = duration.to_milliseconds(stale_for)
 
-  recover_stale_jobs_in_batches(state, now, attempted_before, 0)
+  case stale_for_ms <= 0 {
+    True -> Ok(0)
+    False -> {
+      let attempted_before =
+        timestamp.add(now, duration.milliseconds(-stale_for_ms))
+
+      recover_stale_jobs_in_batches(state, now, attempted_before, 0)
+    }
+  }
 }
 
 fn recover_stale_jobs_in_batches(

--- a/src/kairos/queue_reaper.gleam
+++ b/src/kairos/queue_reaper.gleam
@@ -1,0 +1,139 @@
+import gleam/erlang/process
+import gleam/int
+import gleam/otp/actor
+import gleam/otp/supervision.{type ChildSpecification}
+import gleam/result
+import gleam/time/duration
+import gleam/time/timestamp
+import kairos/config
+import kairos/postgres/job_store
+import pog
+
+pub type Message {
+  Recover(
+    now: timestamp.Timestamp,
+    stale_for: duration.Duration,
+    reply_with: process.Subject(Result(Int, job_store.StoreError)),
+  )
+}
+
+type State {
+  State(config: config.Config, queue_name: String)
+}
+
+@internal
+pub fn start(
+  name name: process.Name(Message),
+  config config: config.Config,
+  queue_name queue_name: String,
+) -> Result(actor.Started(Nil), actor.StartError) {
+  actor.new(State(config: config, queue_name: queue_name))
+  |> actor.named(name)
+  |> actor.on_message(handle_message)
+  |> actor.start
+  |> result.map(fn(started) { actor.Started(pid: started.pid, data: Nil) })
+}
+
+@internal
+pub fn supervised(
+  name name: process.Name(Message),
+  config config: config.Config,
+  queue_name queue_name: String,
+) -> ChildSpecification(Nil) {
+  supervision.worker(fn() {
+    start(name: name, config: config, queue_name: queue_name)
+  })
+}
+
+@internal
+pub fn recover(
+  name: process.Name(Message),
+  now: timestamp.Timestamp,
+  stale_for: duration.Duration,
+) -> Result(Int, job_store.StoreError) {
+  actor.call(
+    process.named_subject(name),
+    waiting: 5000,
+    sending: fn(reply_with) {
+      Recover(now: now, stale_for: stale_for, reply_with: reply_with)
+    },
+  )
+}
+
+fn handle_message(state: State, message: Message) -> actor.Next(State, Message) {
+  case message {
+    Recover(now:, stale_for:, reply_with:) -> {
+      process.send(reply_with, recover_stale_jobs(state, now, stale_for))
+      actor.continue(state)
+    }
+  }
+}
+
+fn recover_stale_jobs(
+  state: State,
+  now: timestamp.Timestamp,
+  stale_for: duration.Duration,
+) -> Result(Int, job_store.StoreError) {
+  let State(config:, queue_name:) = state
+  let attempted_before =
+    timestamp.add(
+      now,
+      duration.milliseconds(-duration.to_milliseconds(stale_for)),
+    )
+
+  pog.transaction(config.connection(config), fn(connection) {
+    let stale_jobs =
+      job_store.fetch_stale_executing(connection, queue_name, attempted_before)
+    use stale_jobs <- result.try(stale_jobs)
+    recover_jobs(config, connection, stale_jobs, now, 0)
+  })
+  |> map_transaction_error
+}
+
+fn recover_jobs(
+  config: config.Config,
+  connection: pog.Connection,
+  stale_jobs: List(job_store.PersistedJob),
+  now: timestamp.Timestamp,
+  recovered_count: Int,
+) -> Result(Int, job_store.StoreError) {
+  case stale_jobs {
+    [] -> Ok(recovered_count)
+    [stale_job, ..rest] -> {
+      use _ <- result.try(recover_job(config, connection, stale_job, now))
+      recover_jobs(config, connection, rest, now, recovered_count + 1)
+    }
+  }
+}
+
+fn recover_job(
+  _config: config.Config,
+  connection: pog.Connection,
+  stale_job: job_store.PersistedJob,
+  now: timestamp.Timestamp,
+) -> Result(job_store.PersistedJob, job_store.StoreError) {
+  let job_store.PersistedJob(id:, attempt:, max_attempts:, ..) = stale_job
+  let error = stale_error(attempt)
+
+  case attempt < max_attempts {
+    True -> job_store.retry(connection, id, now, error)
+    False -> job_store.discard(connection, id, now, error)
+  }
+}
+
+fn stale_error(attempt: Int) -> String {
+  "kind=stale attempt="
+  <> int.to_string(attempt)
+  <> " reason=stale execution recovered"
+}
+
+fn map_transaction_error(
+  result: Result(Int, pog.TransactionError(job_store.StoreError)),
+) -> Result(Int, job_store.StoreError) {
+  case result {
+    Ok(recovered_count) -> Ok(recovered_count)
+    Error(pog.TransactionQueryError(error)) ->
+      Error(job_store.QueryFailed(error))
+    Error(pog.TransactionRolledBack(error)) -> Error(error)
+  }
+}

--- a/src/kairos/queue_reaper.gleam
+++ b/src/kairos/queue_reaper.gleam
@@ -9,6 +9,8 @@ import kairos/config
 import kairos/postgres/job_store
 import pog
 
+const recovery_batch_size = 100
+
 pub type Message {
   Recover(
     now: timestamp.Timestamp,
@@ -74,6 +76,15 @@ fn recover_stale_jobs(
   now: timestamp.Timestamp,
   stale_for: duration.Duration,
 ) -> Result(Int, job_store.StoreError) {
+  recover_stale_jobs_in_batches(state, now, stale_for, 0)
+}
+
+fn recover_stale_jobs_in_batches(
+  state: State,
+  now: timestamp.Timestamp,
+  stale_for: duration.Duration,
+  recovered_count: Int,
+) -> Result(Int, job_store.StoreError) {
   let State(config:, queue_name:) = state
   let attempted_before =
     timestamp.add(
@@ -81,17 +92,34 @@ fn recover_stale_jobs(
       duration.milliseconds(-duration.to_milliseconds(stale_for)),
     )
 
-  pog.transaction(config.connection(config), fn(connection) {
-    let stale_jobs =
-      job_store.fetch_stale_executing(connection, queue_name, attempted_before)
-    use stale_jobs <- result.try(stale_jobs)
-    recover_jobs(config, connection, stale_jobs, now, 0)
-  })
-  |> map_transaction_error
+  let recovered_in_batch =
+    pog.transaction(config.connection(config), fn(connection) {
+      let stale_jobs =
+        job_store.fetch_stale_executing(
+          connection,
+          queue_name,
+          attempted_before,
+          recovery_batch_size,
+        )
+      use stale_jobs <- result.try(stale_jobs)
+      recover_jobs(connection, stale_jobs, now, 0)
+    })
+    |> map_transaction_error
+  use recovered_in_batch <- result.try(recovered_in_batch)
+
+  case recovered_in_batch {
+    0 -> Ok(recovered_count)
+    _ ->
+      recover_stale_jobs_in_batches(
+        state,
+        now,
+        stale_for,
+        recovered_count + recovered_in_batch,
+      )
+  }
 }
 
 fn recover_jobs(
-  config: config.Config,
   connection: pog.Connection,
   stale_jobs: List(job_store.PersistedJob),
   now: timestamp.Timestamp,
@@ -100,14 +128,13 @@ fn recover_jobs(
   case stale_jobs {
     [] -> Ok(recovered_count)
     [stale_job, ..rest] -> {
-      use _ <- result.try(recover_job(config, connection, stale_job, now))
-      recover_jobs(config, connection, rest, now, recovered_count + 1)
+      use _ <- result.try(recover_job(connection, stale_job, now))
+      recover_jobs(connection, rest, now, recovered_count + 1)
     }
   }
 }
 
 fn recover_job(
-  _config: config.Config,
   connection: pog.Connection,
   stale_job: job_store.PersistedJob,
   now: timestamp.Timestamp,

--- a/src/kairos/queue_reaper.gleam
+++ b/src/kairos/queue_reaper.gleam
@@ -11,6 +11,8 @@ import pog
 
 const recovery_batch_size = 100
 
+const recovery_timeout_ms = 15_000
+
 pub type Message {
   Recover(
     now: timestamp.Timestamp,
@@ -55,7 +57,7 @@ pub fn recover(
 ) -> Result(Int, job_store.StoreError) {
   actor.call(
     process.named_subject(name),
-    waiting: 5000,
+    waiting: recovery_timeout_ms,
     sending: fn(reply_with) {
       Recover(now: now, stale_for: stale_for, reply_with: reply_with)
     },
@@ -76,21 +78,22 @@ fn recover_stale_jobs(
   now: timestamp.Timestamp,
   stale_for: duration.Duration,
 ) -> Result(Int, job_store.StoreError) {
-  recover_stale_jobs_in_batches(state, now, stale_for, 0)
-}
-
-fn recover_stale_jobs_in_batches(
-  state: State,
-  now: timestamp.Timestamp,
-  stale_for: duration.Duration,
-  recovered_count: Int,
-) -> Result(Int, job_store.StoreError) {
-  let State(config:, queue_name:) = state
   let attempted_before =
     timestamp.add(
       now,
       duration.milliseconds(-duration.to_milliseconds(stale_for)),
     )
+
+  recover_stale_jobs_in_batches(state, now, attempted_before, 0)
+}
+
+fn recover_stale_jobs_in_batches(
+  state: State,
+  now: timestamp.Timestamp,
+  attempted_before: timestamp.Timestamp,
+  recovered_count: Int,
+) -> Result(Int, job_store.StoreError) {
+  let State(config:, queue_name:) = state
 
   let recovered_in_batch =
     pog.transaction(config.connection(config), fn(connection) {
@@ -113,7 +116,7 @@ fn recover_stale_jobs_in_batches(
       recover_stale_jobs_in_batches(
         state,
         now,
-        stale_for,
+        attempted_before,
         recovered_count + recovered_in_batch,
       )
   }

--- a/src/kairos/supervision.gleam
+++ b/src/kairos/supervision.gleam
@@ -48,12 +48,11 @@ pub fn start(
     |> list.fold(
       static_supervisor.new(static_supervisor.OneForOne),
       fn(builder, pair) {
-        let #(runtime_for_queue, queue_definition) = pair
+        let #(runtime_for_queue, _) = pair
         builder
         |> static_supervisor.add(queue_supervisor.supervised(
           config: config,
           runtime: runtime_for_queue,
-          queue_definition: queue_definition,
         ))
       },
     )
@@ -132,6 +131,7 @@ pub fn queue_poller_pid(
   queue_runtime.poller_pid(runtime_for_queue)
 }
 
+@internal
 pub fn queue_reaper_pid(
   runtime: Runtime,
   queue_name: String,

--- a/src/kairos/supervision.gleam
+++ b/src/kairos/supervision.gleam
@@ -8,6 +8,7 @@ import gleam/otp/supervision.{type ChildSpecification}
 import gleam/result
 import kairos/config
 import kairos/job_runner
+import kairos/queue_reaper
 import kairos/supervision/name
 import kairos/supervision/queue_runtime
 import kairos/supervision/queue_supervisor
@@ -25,8 +26,17 @@ pub fn start(
   config config: config.Config,
 ) -> Result(actor.Started(Runtime), actor.StartError) {
   let root_name = name.root_supervisor()
+  let queue_pairs =
+    config.queues(config)
+    |> list.map(fn(queue_definition) {
+      #(queue_runtime.from_queue(queue_definition), queue_definition)
+    })
   let queue_runtimes =
-    config.queues(config) |> list.map(queue_runtime.from_queue)
+    queue_pairs
+    |> list.map(fn(pair) {
+      let #(runtime_for_queue, _) = pair
+      runtime_for_queue
+    })
   let queue_map =
     queue_runtimes
     |> list.map(fn(runtime_for_queue) {
@@ -34,13 +44,16 @@ pub fn start(
     })
     |> dict.from_list
   let builder =
-    queue_runtimes
+    queue_pairs
     |> list.fold(
       static_supervisor.new(static_supervisor.OneForOne),
-      fn(builder, runtime_for_queue) {
+      fn(builder, pair) {
+        let #(runtime_for_queue, queue_definition) = pair
         builder
         |> static_supervisor.add(queue_supervisor.supervised(
+          config: config,
           runtime: runtime_for_queue,
+          queue_definition: queue_definition,
         ))
       },
     )
@@ -117,6 +130,23 @@ pub fn queue_poller_pid(
 ) -> Result(process.Pid, Nil) {
   use runtime_for_queue <- result.try(find_queue_runtime(runtime, queue_name))
   queue_runtime.poller_pid(runtime_for_queue)
+}
+
+pub fn queue_reaper_pid(
+  runtime: Runtime,
+  queue_name: String,
+) -> Result(process.Pid, Nil) {
+  use runtime_for_queue <- result.try(find_queue_runtime(runtime, queue_name))
+  queue_runtime.reaper_pid(runtime_for_queue)
+}
+
+@internal
+pub fn queue_reaper_name(
+  runtime: Runtime,
+  queue_name: String,
+) -> Result(process.Name(queue_reaper.Message), Nil) {
+  use runtime_for_queue <- result.try(find_queue_runtime(runtime, queue_name))
+  Ok(queue_runtime.reaper_name(runtime_for_queue))
 }
 
 pub fn root_pid(runtime: Runtime) -> Result(process.Pid, Nil) {

--- a/src/kairos/supervision/name.gleam
+++ b/src/kairos/supervision/name.gleam
@@ -2,6 +2,7 @@ import gleam/erlang/process
 import gleam/otp/factory_supervisor
 import gleam/string
 import kairos/job_runner
+import kairos/queue_reaper
 
 @internal
 pub fn root_supervisor() -> process.Name(Nil) {
@@ -23,6 +24,11 @@ pub fn queue_runner_supervisor(
 @internal
 pub fn queue_poller(queue_name: String) -> process.Name(Nil) {
   process.new_name("kairos-queue-poller-" <> sanitize(queue_name))
+}
+
+@internal
+pub fn queue_reaper(queue_name: String) -> process.Name(queue_reaper.Message) {
+  process.new_name("kairos-queue-reaper-" <> sanitize(queue_name))
 }
 
 fn sanitize(name: String) -> String {

--- a/src/kairos/supervision/queue_runtime.gleam
+++ b/src/kairos/supervision/queue_runtime.gleam
@@ -2,6 +2,7 @@ import gleam/erlang/process
 import gleam/otp/factory_supervisor
 import kairos/job_runner
 import kairos/queue
+import kairos/queue_reaper
 import kairos/supervision/name
 
 pub opaque type QueueRuntime {
@@ -12,6 +13,7 @@ pub opaque type QueueRuntime {
       factory_supervisor.Message(job_runner.RunnerArg, String),
     ),
     poller_name: process.Name(Nil),
+    reaper_name: process.Name(queue_reaper.Message),
   )
 }
 
@@ -24,6 +26,7 @@ pub fn from_queue(queue_definition: queue.Queue) -> QueueRuntime {
     supervisor_name: name.queue_supervisor(queue_name),
     runner_supervisor_name: name.queue_runner_supervisor(queue_name),
     poller_name: name.queue_poller(queue_name),
+    reaper_name: name.queue_reaper(queue_name),
   )
 }
 
@@ -53,6 +56,12 @@ pub fn poller_name(runtime: QueueRuntime) -> process.Name(Nil) {
 }
 
 @internal
+pub fn reaper_name(runtime: QueueRuntime) -> process.Name(queue_reaper.Message) {
+  let QueueRuntime(reaper_name:, ..) = runtime
+  reaper_name
+}
+
+@internal
 pub fn supervisor_pid(runtime: QueueRuntime) -> Result(process.Pid, Nil) {
   process.named(supervisor_name(runtime))
 }
@@ -65,4 +74,9 @@ pub fn runner_supervisor_pid(runtime: QueueRuntime) -> Result(process.Pid, Nil) 
 @internal
 pub fn poller_pid(runtime: QueueRuntime) -> Result(process.Pid, Nil) {
   process.named(poller_name(runtime))
+}
+
+@internal
+pub fn reaper_pid(runtime: QueueRuntime) -> Result(process.Pid, Nil) {
+  process.named(reaper_name(runtime))
 }

--- a/src/kairos/supervision/queue_supervisor.gleam
+++ b/src/kairos/supervision/queue_supervisor.gleam
@@ -2,15 +2,21 @@ import gleam/otp/actor
 import gleam/otp/factory_supervisor
 import gleam/otp/static_supervisor
 import gleam/otp/supervision.{type ChildSpecification}
+import kairos/config
 import kairos/job_runner
+import kairos/queue
+import kairos/queue_reaper
 import kairos/supervision/queue_runtime
 import kairos/supervision/registered_supervisor
 import kairos/supervision/stub_actor
 
 @internal
 pub fn start(
+  config config: config.Config,
   runtime runtime: queue_runtime.QueueRuntime,
+  queue_definition queue_definition: queue.Queue,
 ) -> Result(actor.Started(queue_runtime.QueueRuntime), actor.StartError) {
+  let queue_name = queue.name(queue_definition)
   let builder =
     static_supervisor.new(static_supervisor.OneForAll)
     |> static_supervisor.add(
@@ -21,6 +27,11 @@ pub fn start(
     |> static_supervisor.add(
       stub_actor.supervised(name: queue_runtime.poller_name(runtime)),
     )
+    |> static_supervisor.add(queue_reaper.supervised(
+      name: queue_runtime.reaper_name(runtime),
+      config: config,
+      queue_name: queue_name,
+    ))
 
   case
     registered_supervisor.start(
@@ -36,7 +47,11 @@ pub fn start(
 
 @internal
 pub fn supervised(
+  config config: config.Config,
   runtime runtime: queue_runtime.QueueRuntime,
+  queue_definition queue_definition: queue.Queue,
 ) -> ChildSpecification(queue_runtime.QueueRuntime) {
-  supervision.supervisor(fn() { start(runtime: runtime) })
+  supervision.supervisor(fn() {
+    start(config: config, runtime: runtime, queue_definition: queue_definition)
+  })
 }

--- a/src/kairos/supervision/queue_supervisor.gleam
+++ b/src/kairos/supervision/queue_supervisor.gleam
@@ -4,7 +4,6 @@ import gleam/otp/static_supervisor
 import gleam/otp/supervision.{type ChildSpecification}
 import kairos/config
 import kairos/job_runner
-import kairos/queue
 import kairos/queue_reaper
 import kairos/supervision/queue_runtime
 import kairos/supervision/registered_supervisor
@@ -14,9 +13,7 @@ import kairos/supervision/stub_actor
 pub fn start(
   config config: config.Config,
   runtime runtime: queue_runtime.QueueRuntime,
-  queue_definition queue_definition: queue.Queue,
 ) -> Result(actor.Started(queue_runtime.QueueRuntime), actor.StartError) {
-  let queue_name = queue.name(queue_definition)
   let builder =
     static_supervisor.new(static_supervisor.OneForAll)
     |> static_supervisor.add(
@@ -30,7 +27,7 @@ pub fn start(
     |> static_supervisor.add(queue_reaper.supervised(
       name: queue_runtime.reaper_name(runtime),
       config: config,
-      queue_name: queue_name,
+      queue_name: queue_runtime.name(runtime),
     ))
 
   case
@@ -49,9 +46,6 @@ pub fn start(
 pub fn supervised(
   config config: config.Config,
   runtime runtime: queue_runtime.QueueRuntime,
-  queue_definition queue_definition: queue.Queue,
 ) -> ChildSpecification(queue_runtime.QueueRuntime) {
-  supervision.supervisor(fn() {
-    start(config: config, runtime: runtime, queue_definition: queue_definition)
-  })
+  supervision.supervisor(fn() { start(config: config, runtime: runtime) })
 }

--- a/test/kairos/cancellation_test.gleam
+++ b/test/kairos/cancellation_test.gleam
@@ -1,4 +1,6 @@
+import gleam/list
 import gleam/option.{None, Some}
+import gleam/string
 import gleam/time/duration
 import gleam/time/timestamp
 import gleeunit
@@ -55,12 +57,18 @@ pub fn cancel_at_marks_pending_and_scheduled_jobs_cancelled_test() {
       job_store.fetch(connection, scheduled_id)
     let expected_now = test_db.to_postgres_precision(now)
 
-    assert_cancelled(cancelled_pending, expected_now, [
+    assert_cancelled(
+      cancelled_pending,
+      expected_now,
+      1,
       "kind=cancel attempt=0 reason=cancelled before execution",
-    ])
-    assert_cancelled(cancelled_scheduled, expected_now, [
+    )
+    assert_cancelled(
+      cancelled_scheduled,
+      expected_now,
+      1,
       "kind=cancel attempt=0 reason=cancelled before execution",
-    ])
+    )
   })
 }
 
@@ -116,10 +124,31 @@ pub fn cancel_at_preserves_retry_attempt_count_for_retryable_jobs_test() {
     let assert Ok(Some(cancelled_job)) = job_store.fetch(connection, id)
     let expected_now = test_db.to_postgres_precision(cancelled_at)
 
-    assert_cancelled(cancelled_job, expected_now, [
-      "kind=retry attempt=1 reason=temporary failure",
+    assert_cancelled(
+      cancelled_job,
+      expected_now,
+      2,
       "kind=cancel attempt=2 reason=cancelled before execution",
-    ])
+    )
+
+    Nil
+  })
+}
+
+pub fn cancel_at_returns_not_found_for_missing_jobs_test() {
+  test_db.with_database(fn(connection) {
+    let assert Ok(default_queue) =
+      queue.new(name: "default", concurrency: 5, poll_interval_ms: 1000)
+    let contract = example_worker()
+    let assert Ok(kairos_config) =
+      config.new(connection: connection, queues: [default_queue], workers: [
+        worker.register(contract),
+      ])
+    let missing_id = "00000000-0000-0000-0000-000000000000"
+
+    let assert Error(kairos.JobNotFound(id)) =
+      kairos.cancel_at(kairos_config, missing_id, timestamp.system_time())
+    assert id == missing_id
 
     Nil
   })
@@ -141,7 +170,8 @@ fn example_worker() -> worker.Worker(ExampleArgs) {
 fn assert_cancelled(
   persisted_job: job_store.PersistedJob,
   expected_now: timestamp.Timestamp,
-  expected_errors: List(String),
+  expected_error_count: Int,
+  expected_last_error: String,
 ) -> Nil {
   let job_store.PersistedJob(
     state: state,
@@ -152,7 +182,9 @@ fn assert_cancelled(
 
   assert state == job.Cancelled
   assert cancelled_at == Some(expected_now)
-  assert errors == expected_errors
+  assert list.length(errors) == expected_error_count
+  let assert Ok(last_error) = list.last(errors)
+  assert string.contains(last_error, expected_last_error)
 }
 
 fn insert_retryable_job(

--- a/test/kairos/cancellation_test.gleam
+++ b/test/kairos/cancellation_test.gleam
@@ -1,0 +1,186 @@
+import gleam/option.{None, Some}
+import gleam/time/duration
+import gleam/time/timestamp
+import gleeunit
+import kairos
+import kairos/config
+import kairos/job
+import kairos/postgres/job_store
+import kairos/postgres/test_db
+import kairos/queue
+import kairos/worker
+import pog
+
+type ExampleArgs {
+  ExampleArgs(name: String)
+}
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+pub fn cancel_at_marks_pending_and_scheduled_jobs_cancelled_test() {
+  test_db.with_database(fn(connection) {
+    let assert Ok(default_queue) =
+      queue.new(name: "default", concurrency: 5, poll_interval_ms: 1000)
+    let contract = example_worker()
+    let assert Ok(kairos_config) =
+      config.new(connection: connection, queues: [default_queue], workers: [
+        worker.register(contract),
+      ])
+    let now = timestamp.system_time()
+    let later = timestamp.add(now, duration.minutes(10))
+    let scheduled_options =
+      job.with_schedule(job.default_enqueue_options(), job.At(later))
+
+    let assert Ok(pending) =
+      kairos.enqueue(kairos_config, contract, ExampleArgs(name: "pending"))
+    let assert Ok(scheduled) =
+      kairos.enqueue_with(
+        kairos_config,
+        contract,
+        ExampleArgs(name: "scheduled"),
+        scheduled_options,
+      )
+
+    let job.EnqueuedJob(id: pending_id, ..) = pending
+    let job.EnqueuedJob(id: scheduled_id, ..) = scheduled
+
+    let assert Ok(Nil) = kairos.cancel_at(kairos_config, pending_id, now)
+    let assert Ok(Nil) = kairos.cancel_at(kairos_config, scheduled_id, now)
+
+    let assert Ok(Some(cancelled_pending)) =
+      job_store.fetch(connection, pending_id)
+    let assert Ok(Some(cancelled_scheduled)) =
+      job_store.fetch(connection, scheduled_id)
+    let expected_now = test_db.to_postgres_precision(now)
+
+    assert_cancelled(cancelled_pending, expected_now, [
+      "kind=cancel attempt=0 reason=cancelled before execution",
+    ])
+    assert_cancelled(cancelled_scheduled, expected_now, [
+      "kind=cancel attempt=0 reason=cancelled before execution",
+    ])
+  })
+}
+
+pub fn cancel_at_rejects_already_executing_jobs_test() {
+  test_db.with_database(fn(connection) {
+    let assert Ok(default_queue) =
+      queue.new(name: "default", concurrency: 5, poll_interval_ms: 1000)
+    let contract = example_worker()
+    let assert Ok(kairos_config) =
+      config.new(connection: connection, queues: [default_queue], workers: [
+        worker.register(contract),
+      ])
+    let now = timestamp.system_time()
+
+    let assert Ok(enqueued) =
+      kairos.enqueue(kairos_config, contract, ExampleArgs(name: "pending"))
+    let job.EnqueuedJob(id:, ..) = enqueued
+    let assert Ok([_claimed]) =
+      job_store.claim_available(
+        connection,
+        "default",
+        timestamp.system_time(),
+        1,
+      )
+
+    let assert Error(kairos.JobNotCancellable(job.Executing)) =
+      kairos.cancel_at(kairos_config, id, now)
+
+    Nil
+  })
+}
+
+pub fn cancel_at_preserves_retry_attempt_count_for_retryable_jobs_test() {
+  test_db.with_database(fn(connection) {
+    let assert Ok(default_queue) =
+      queue.new(name: "default", concurrency: 5, poll_interval_ms: 1000)
+    let contract = example_worker()
+    let assert Ok(kairos_config) =
+      config.new(connection: connection, queues: [default_queue], workers: [
+        worker.register(contract),
+      ])
+    let retryable_job =
+      insert_retryable_job(
+        connection,
+        "workers.example",
+        2,
+        timestamp.system_time(),
+      )
+    let job_store.PersistedJob(id:, ..) = retryable_job
+    let cancelled_at = timestamp.system_time()
+
+    let assert Ok(Nil) = kairos.cancel_at(kairos_config, id, cancelled_at)
+    let assert Ok(Some(cancelled_job)) = job_store.fetch(connection, id)
+    let expected_now = test_db.to_postgres_precision(cancelled_at)
+
+    assert_cancelled(cancelled_job, expected_now, [
+      "kind=retry attempt=1 reason=temporary failure",
+      "kind=cancel attempt=2 reason=cancelled before execution",
+    ])
+
+    Nil
+  })
+}
+
+fn example_worker() -> worker.Worker(ExampleArgs) {
+  worker.new(
+    "workers.example",
+    fn(args) {
+      let ExampleArgs(name:) = args
+      name
+    },
+    fn(payload) { Ok(ExampleArgs(name: payload)) },
+    fn(_args) { worker.Success },
+    job.default_enqueue_options(),
+  )
+}
+
+fn assert_cancelled(
+  persisted_job: job_store.PersistedJob,
+  expected_now: timestamp.Timestamp,
+  expected_errors: List(String),
+) -> Nil {
+  let job_store.PersistedJob(
+    state: state,
+    cancelled_at: cancelled_at,
+    errors: errors,
+    ..,
+  ) = persisted_job
+
+  assert state == job.Cancelled
+  assert cancelled_at == Some(expected_now)
+  assert errors == expected_errors
+}
+
+fn insert_retryable_job(
+  connection: pog.Connection,
+  worker_name: String,
+  attempt: Int,
+  scheduled_at: timestamp.Timestamp,
+) -> job_store.PersistedJob {
+  let assert Ok(persisted_job) =
+    job_store.insert(
+      connection,
+      job_store.JobInsert(
+        worker_name: worker_name,
+        payload: "retryable",
+        state: job.Retryable,
+        queue_name: "default",
+        priority: 0,
+        attempt: attempt,
+        max_attempts: 5,
+        unique_key: None,
+        errors: ["kind=retry attempt=1 reason=temporary failure"],
+        scheduled_at: scheduled_at,
+        attempted_at: Some(scheduled_at),
+        completed_at: None,
+        discarded_at: None,
+        cancelled_at: None,
+      ),
+    )
+
+  persisted_job
+}

--- a/test/kairos/recovery_test.gleam
+++ b/test/kairos/recovery_test.gleam
@@ -1,5 +1,7 @@
 import gleam/erlang/process
+import gleam/list
 import gleam/option.{None, Some}
+import gleam/string
 import gleam/time/duration
 import gleam/time/timestamp
 import gleeunit
@@ -68,11 +70,13 @@ pub fn recover_stale_retries_and_discards_stale_executing_jobs_test() {
     assert_retryable(
       stored_retryable,
       test_db.to_postgres_precision(now),
+      1,
       "kind=stale attempt=1 reason=stale execution recovered",
     )
     assert_discarded(
       stored_exhausted,
       test_db.to_postgres_precision(now),
+      1,
       "kind=stale attempt=3 reason=stale execution recovered",
     )
 
@@ -122,10 +126,48 @@ pub fn recover_stale_restores_abandoned_jobs_after_restart_test() {
     assert_retryable(
       recovered_job,
       test_db.to_postgres_precision(recover_now),
+      1,
       "kind=stale attempt=1 reason=stale execution recovered",
     )
 
     process.send_exit(second_runtime.pid)
+  })
+}
+
+pub fn recover_stale_ignores_recent_executing_jobs_test() {
+  test_db.with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let recent_attempted_at = timestamp.add(now, duration.minutes(-2))
+    let contract = result_worker("workers.recent", worker.Success)
+    let assert Ok(default_queue) =
+      queue.new(name: "default", concurrency: 5, poll_interval_ms: 1000)
+    let assert Ok(kairos_config) =
+      config.new(connection: connection, queues: [default_queue], workers: [
+        worker.register(contract),
+      ])
+    let assert Ok(started) = kairos.start(kairos_config)
+    let recent_job =
+      insert_executing_job(
+        connection,
+        worker_name: "workers.recent",
+        attempt: 1,
+        max_attempts: 3,
+        attempted_at: recent_attempted_at,
+      )
+
+    let assert Ok(0) =
+      kairos.recover_stale(started.data, "default", now, duration.minutes(5))
+
+    let job_store.PersistedJob(id:, ..) = recent_job
+    let assert Ok(Some(stored_job)) = job_store.fetch(connection, id)
+    let job_store.PersistedJob(state:, attempted_at:, errors:, ..) = stored_job
+
+    assert state == job.Executing
+    assert attempted_at
+      == Some(test_db.to_postgres_precision(recent_attempted_at))
+    assert list.is_empty(errors)
+
+    process.send_exit(started.pid)
   })
 }
 
@@ -179,7 +221,8 @@ fn insert_executing_job(
 fn assert_retryable(
   persisted_job: job_store.PersistedJob,
   expected_scheduled_at: timestamp.Timestamp,
-  expected_error: String,
+  expected_error_count: Int,
+  expected_last_error: String,
 ) -> Nil {
   let job_store.PersistedJob(
     state: state,
@@ -190,13 +233,16 @@ fn assert_retryable(
 
   assert state == job.Retryable
   assert scheduled_at == expected_scheduled_at
-  assert errors == [expected_error]
+  assert list.length(errors) == expected_error_count
+  let assert Ok(last_error) = list.last(errors)
+  assert string.contains(last_error, expected_last_error)
 }
 
 fn assert_discarded(
   persisted_job: job_store.PersistedJob,
   expected_now: timestamp.Timestamp,
-  expected_error: String,
+  expected_error_count: Int,
+  expected_last_error: String,
 ) -> Nil {
   let job_store.PersistedJob(
     state: state,
@@ -207,5 +253,7 @@ fn assert_discarded(
 
   assert state == job.Discarded
   assert discarded_at == Some(expected_now)
-  assert errors == [expected_error]
+  assert list.length(errors) == expected_error_count
+  let assert Ok(last_error) = list.last(errors)
+  assert string.contains(last_error, expected_last_error)
 }

--- a/test/kairos/recovery_test.gleam
+++ b/test/kairos/recovery_test.gleam
@@ -199,6 +199,8 @@ pub fn recover_stale_ignores_non_positive_stale_window_test() {
         now,
         duration.milliseconds(0),
       )
+    let assert Ok(0) =
+      kairos.recover_stale(started.data, "default", now, duration.minutes(-1))
 
     let job_store.PersistedJob(id:, ..) = stale_job
     let assert Ok(Some(stored_job)) = job_store.fetch(connection, id)
@@ -208,6 +210,28 @@ pub fn recover_stale_ignores_non_positive_stale_window_test() {
     assert attempted_at
       == Some(test_db.to_postgres_precision(stale_attempted_at))
     assert list.is_empty(errors)
+
+    process.send_exit(started.pid)
+  })
+}
+
+pub fn recover_stale_returns_error_for_unknown_queue_test() {
+  test_db.with_database(fn(connection) {
+    let assert Ok(default_queue) =
+      queue.new(name: "default", concurrency: 5, poll_interval_ms: 1000)
+    let assert Ok(kairos_config) =
+      config.new(connection: connection, queues: [default_queue], workers: [])
+    let assert Ok(started) = kairos.start(kairos_config)
+
+    let result =
+      kairos.recover_stale(
+        started.data,
+        "missing",
+        timestamp.system_time(),
+        duration.minutes(5),
+      )
+
+    assert result == Error(kairos.QueueRuntimeUnavailable("missing"))
 
     process.send_exit(started.pid)
   })

--- a/test/kairos/recovery_test.gleam
+++ b/test/kairos/recovery_test.gleam
@@ -171,6 +171,48 @@ pub fn recover_stale_ignores_recent_executing_jobs_test() {
   })
 }
 
+pub fn recover_stale_ignores_non_positive_stale_window_test() {
+  test_db.with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let stale_attempted_at = timestamp.add(now, duration.minutes(-10))
+    let contract = result_worker("workers.non_positive", worker.Success)
+    let assert Ok(default_queue) =
+      queue.new(name: "default", concurrency: 5, poll_interval_ms: 1000)
+    let assert Ok(kairos_config) =
+      config.new(connection: connection, queues: [default_queue], workers: [
+        worker.register(contract),
+      ])
+    let assert Ok(started) = kairos.start(kairos_config)
+    let stale_job =
+      insert_executing_job(
+        connection,
+        worker_name: "workers.non_positive",
+        attempt: 1,
+        max_attempts: 3,
+        attempted_at: stale_attempted_at,
+      )
+
+    let assert Ok(0) =
+      kairos.recover_stale(
+        started.data,
+        "default",
+        now,
+        duration.milliseconds(0),
+      )
+
+    let job_store.PersistedJob(id:, ..) = stale_job
+    let assert Ok(Some(stored_job)) = job_store.fetch(connection, id)
+    let job_store.PersistedJob(state:, attempted_at:, errors:, ..) = stored_job
+
+    assert state == job.Executing
+    assert attempted_at
+      == Some(test_db.to_postgres_precision(stale_attempted_at))
+    assert list.is_empty(errors)
+
+    process.send_exit(started.pid)
+  })
+}
+
 fn result_worker(
   name: String,
   result: worker.PerformResult,

--- a/test/kairos/recovery_test.gleam
+++ b/test/kairos/recovery_test.gleam
@@ -213,6 +213,40 @@ pub fn recover_stale_ignores_non_positive_stale_window_test() {
   })
 }
 
+pub fn recover_stale_processes_multiple_batches_test() {
+  test_db.with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let stale_attempted_at = timestamp.add(now, duration.minutes(-10))
+    let contract = result_worker("workers.batched", worker.Success)
+    let assert Ok(default_queue) =
+      queue.new(name: "default", concurrency: 5, poll_interval_ms: 1000)
+    let assert Ok(kairos_config) =
+      config.new(connection: connection, queues: [default_queue], workers: [
+        worker.register(contract),
+      ])
+    let assert Ok(started) = kairos.start(kairos_config)
+    let stale_jobs =
+      insert_executing_jobs(
+        connection,
+        worker_name: "workers.batched",
+        count: 101,
+        attempted_at: stale_attempted_at,
+        jobs: [],
+      )
+
+    let assert Ok(101) =
+      kairos.recover_stale(started.data, "default", now, duration.minutes(5))
+
+    assert_jobs_recovered_retryable(
+      connection,
+      stale_jobs,
+      test_db.to_postgres_precision(now),
+    )
+
+    process.send_exit(started.pid)
+  })
+}
+
 fn result_worker(
   name: String,
   result: worker.PerformResult,
@@ -258,6 +292,55 @@ fn insert_executing_job(
     )
 
   persisted_job
+}
+
+fn insert_executing_jobs(
+  connection connection: pog.Connection,
+  worker_name worker_name: String,
+  count count: Int,
+  attempted_at attempted_at: timestamp.Timestamp,
+  jobs jobs: List(job_store.PersistedJob),
+) -> List(job_store.PersistedJob) {
+  case count {
+    0 -> list.reverse(jobs)
+    _ ->
+      insert_executing_jobs(
+        connection: connection,
+        worker_name: worker_name,
+        count: count - 1,
+        attempted_at: attempted_at,
+        jobs: [
+          insert_executing_job(
+            connection,
+            worker_name: worker_name,
+            attempt: 1,
+            max_attempts: 3,
+            attempted_at: attempted_at,
+          ),
+          ..jobs
+        ],
+      )
+  }
+}
+
+fn assert_jobs_recovered_retryable(
+  connection: pog.Connection,
+  jobs: List(job_store.PersistedJob),
+  expected_scheduled_at: timestamp.Timestamp,
+) -> Nil {
+  case jobs {
+    [] -> Nil
+    [job_store.PersistedJob(id:, ..), ..rest] -> {
+      let assert Ok(Some(stored_job)) = job_store.fetch(connection, id)
+      assert_retryable(
+        stored_job,
+        expected_scheduled_at,
+        1,
+        "kind=stale attempt=1 reason=stale execution recovered",
+      )
+      assert_jobs_recovered_retryable(connection, rest, expected_scheduled_at)
+    }
+  }
 }
 
 fn assert_retryable(

--- a/test/kairos/recovery_test.gleam
+++ b/test/kairos/recovery_test.gleam
@@ -1,0 +1,211 @@
+import gleam/erlang/process
+import gleam/option.{None, Some}
+import gleam/time/duration
+import gleam/time/timestamp
+import gleeunit
+import kairos
+import kairos/backoff
+import kairos/config
+import kairos/job
+import kairos/postgres/job_store
+import kairos/postgres/test_db
+import kairos/queue
+import kairos/worker
+import pog
+
+type ExampleArgs {
+  ExampleArgs(name: String)
+}
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+pub fn recover_stale_retries_and_discards_stale_executing_jobs_test() {
+  test_db.with_database(fn(connection) {
+    let now = timestamp.system_time()
+    let stale_attempted_at = timestamp.add(now, duration.minutes(-10))
+    let retry_contract =
+      worker.with_backoff(
+        result_worker("workers.retry", worker.Success),
+        backoff.constant_policy(90),
+      )
+    let assert Ok(default_queue) =
+      queue.new(name: "default", concurrency: 5, poll_interval_ms: 1000)
+    let assert Ok(kairos_config) =
+      config.new(connection: connection, queues: [default_queue], workers: [
+        worker.register(retry_contract),
+      ])
+    let assert Ok(started) = kairos.start(kairos_config)
+
+    let retryable_job =
+      insert_executing_job(
+        connection,
+        worker_name: "workers.retry",
+        attempt: 1,
+        max_attempts: 3,
+        attempted_at: stale_attempted_at,
+      )
+    let exhausted_job =
+      insert_executing_job(
+        connection,
+        worker_name: "workers.retry",
+        attempt: 3,
+        max_attempts: 3,
+        attempted_at: stale_attempted_at,
+      )
+
+    let assert Ok(2) =
+      kairos.recover_stale(started.data, "default", now, duration.minutes(5))
+
+    let job_store.PersistedJob(id: retryable_id, ..) = retryable_job
+    let job_store.PersistedJob(id: exhausted_id, ..) = exhausted_job
+    let assert Ok(Some(stored_retryable)) =
+      job_store.fetch(connection, retryable_id)
+    let assert Ok(Some(stored_exhausted)) =
+      job_store.fetch(connection, exhausted_id)
+
+    assert_retryable(
+      stored_retryable,
+      test_db.to_postgres_precision(now),
+      "kind=stale attempt=1 reason=stale execution recovered",
+    )
+    assert_discarded(
+      stored_exhausted,
+      test_db.to_postgres_precision(now),
+      "kind=stale attempt=3 reason=stale execution recovered",
+    )
+
+    process.send_exit(started.pid)
+  })
+}
+
+pub fn recover_stale_restores_abandoned_jobs_after_restart_test() {
+  test_db.with_database(fn(connection) {
+    let claim_now =
+      timestamp.add(timestamp.system_time(), duration.minutes(-10))
+    let recover_now = timestamp.system_time()
+    let contract = result_worker("workers.restart", worker.Success)
+    let assert Ok(default_queue) =
+      queue.new(name: "default", concurrency: 5, poll_interval_ms: 1000)
+    let assert Ok(kairos_config) =
+      config.new(connection: connection, queues: [default_queue], workers: [
+        worker.register(contract),
+      ])
+    let assert Ok(first_runtime) = kairos.start(kairos_config)
+    let scheduled_options =
+      job.with_schedule(job.default_enqueue_options(), job.At(claim_now))
+    let assert Ok(enqueued) =
+      kairos.enqueue_with(
+        kairos_config,
+        contract,
+        ExampleArgs(name: "restart"),
+        scheduled_options,
+      )
+    let job.EnqueuedJob(id:, ..) = enqueued
+
+    let assert Ok([_claimed]) =
+      job_store.claim_available(connection, "default", claim_now, 1)
+    process.send_exit(first_runtime.pid)
+
+    let assert Ok(second_runtime) = kairos.start(kairos_config)
+    let assert Ok(1) =
+      kairos.recover_stale(
+        second_runtime.data,
+        "default",
+        recover_now,
+        duration.minutes(5),
+      )
+
+    let assert Ok(Some(recovered_job)) = job_store.fetch(connection, id)
+
+    assert_retryable(
+      recovered_job,
+      test_db.to_postgres_precision(recover_now),
+      "kind=stale attempt=1 reason=stale execution recovered",
+    )
+
+    process.send_exit(second_runtime.pid)
+  })
+}
+
+fn result_worker(
+  name: String,
+  result: worker.PerformResult,
+) -> worker.Worker(ExampleArgs) {
+  worker.new(
+    name,
+    fn(args) {
+      let ExampleArgs(name:) = args
+      name
+    },
+    fn(payload) { Ok(ExampleArgs(name: payload)) },
+    fn(_args) { result },
+    job.default_enqueue_options(),
+  )
+}
+
+fn insert_executing_job(
+  connection: pog.Connection,
+  worker_name worker_name: String,
+  attempt attempt: Int,
+  max_attempts max_attempts: Int,
+  attempted_at attempted_at: timestamp.Timestamp,
+) -> job_store.PersistedJob {
+  let assert Ok(persisted_job) =
+    job_store.insert(
+      connection,
+      job_store.JobInsert(
+        worker_name: worker_name,
+        payload: "kairos",
+        state: job.Executing,
+        queue_name: "default",
+        priority: 0,
+        attempt: attempt,
+        max_attempts: max_attempts,
+        unique_key: None,
+        errors: [],
+        scheduled_at: attempted_at,
+        attempted_at: Some(attempted_at),
+        completed_at: None,
+        discarded_at: None,
+        cancelled_at: None,
+      ),
+    )
+
+  persisted_job
+}
+
+fn assert_retryable(
+  persisted_job: job_store.PersistedJob,
+  expected_scheduled_at: timestamp.Timestamp,
+  expected_error: String,
+) -> Nil {
+  let job_store.PersistedJob(
+    state: state,
+    scheduled_at: scheduled_at,
+    errors: errors,
+    ..,
+  ) = persisted_job
+
+  assert state == job.Retryable
+  assert scheduled_at == expected_scheduled_at
+  assert errors == [expected_error]
+}
+
+fn assert_discarded(
+  persisted_job: job_store.PersistedJob,
+  expected_now: timestamp.Timestamp,
+  expected_error: String,
+) -> Nil {
+  let job_store.PersistedJob(
+    state: state,
+    discarded_at: discarded_at,
+    errors: errors,
+    ..,
+  ) = persisted_job
+
+  assert state == job.Discarded
+  assert discarded_at == Some(expected_now)
+  assert errors == [expected_error]
+}

--- a/test/kairos/supervision_test.gleam
+++ b/test/kairos/supervision_test.gleam
@@ -30,12 +30,15 @@ pub fn start_builds_queue_supervisors_and_stub_processes_test() {
     supervision.queue_runner_supervisor_pid(runtime, "mailers")
   let assert Ok(default_poller) =
     supervision.queue_poller_pid(runtime, "default")
+  let assert Ok(default_reaper) =
+    supervision.queue_reaper_pid(runtime, "default")
 
   assert process.is_alive(root_pid)
   assert process.is_alive(default_supervisor)
   assert process.is_alive(default_runner_supervisor)
   assert process.is_alive(mailers_runner_supervisor)
   assert process.is_alive(default_poller)
+  assert process.is_alive(default_reaper)
 
   process.send_exit(started.pid)
 }

--- a/test/kairos/supervision_test.gleam
+++ b/test/kairos/supervision_test.gleam
@@ -32,6 +32,8 @@ pub fn start_builds_queue_supervisors_and_stub_processes_test() {
     supervision.queue_poller_pid(runtime, "default")
   let assert Ok(default_reaper) =
     supervision.queue_reaper_pid(runtime, "default")
+  let assert Ok(mailers_reaper) =
+    supervision.queue_reaper_pid(runtime, "mailers")
 
   assert process.is_alive(root_pid)
   assert process.is_alive(default_supervisor)
@@ -39,6 +41,7 @@ pub fn start_builds_queue_supervisors_and_stub_processes_test() {
   assert process.is_alive(mailers_runner_supervisor)
   assert process.is_alive(default_poller)
   assert process.is_alive(default_reaper)
+  assert process.is_alive(mailers_reaper)
 
   process.send_exit(started.pid)
 }


### PR DESCRIPTION
## Summary

- add queued-job cancellation and stale execution recovery to the public runtime API
- add a queue reaper actor plus transactional stale-job selection in the PostgreSQL store
- expand integration coverage and update the README to reflect the current runtime surface

Closes #10

## Validation

- `gleam format`
- `gleam check`
- `gleam test` (`51 passed, no failures`)
- smoke app run in `/tmp/kairos_issue_10_smoke_app`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cancel pending, scheduled, and retryable jobs before they start; automatically recover stale executing jobs and restore or discard them based on retry rules.
  * Supervised dispatching of claimed jobs for safer runtime control.

* **Documentation**
  * README updated with supervised dispatch example and a new "Cancellation And Recovery" section showing usage.

* **Tests**
  * Added integration tests covering cancellation scenarios, stale-job recovery, and supervision wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->