### PR TITLE
Add admin APIs for job inspection and mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/ccarvalho-eng/kairos/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ccarvalho-eng/kairos/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](./LICENSE)
 
-Typed background jobs for Gleam.
+Background jobs for Gleam.
 
 </div>
 
@@ -33,10 +33,10 @@ Kairos on `main` currently supports:
 - configuring named queues and supervising Kairos inside a host app
 - enqueueing jobs with queue, priority, max-attempts, and schedule options
 - storing jobs in PostgreSQL and atomically claiming runnable jobs per queue
-- inspecting persisted jobs through a typed admin query API
+- inspecting persisted jobs through an admin query API
 - polling queues automatically and dispatching claimed jobs through supervised runners
 - cancelling queued jobs before execution
-- manually retrying discarded or cancelled jobs through a typed admin API
+- manually retrying discarded or cancelled jobs through an admin API
 - retrying failed jobs with configurable backoff
 - recovering stale `executing` jobs back into a runnable or terminal state
 
@@ -68,7 +68,7 @@ The full setup path, worker examples, and per-job option overrides live in [`doc
 
 On `main`, Kairos can:
 
-- enqueue typed jobs
+- enqueue jobs
 - poll queues automatically
 - claim runnable jobs atomically
 - execute jobs in supervised runners

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Kairos on `main` currently supports:
 - configuring named queues and supervising Kairos inside a host app
 - enqueueing jobs with queue, priority, max-attempts, and schedule options
 - storing jobs in PostgreSQL and atomically claiming runnable jobs per queue
-- inspecting persisted jobs through an admin query API
+- inspecting persisted jobs through a bounded admin query API
 - polling queues automatically and dispatching claimed jobs through supervised runners
 - cancelling queued jobs before execution
 - manually retrying discarded or cancelled jobs through an admin API

--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ Kairos on `main` currently supports:
 - configuring named queues and supervising Kairos inside a host app
 - enqueueing jobs with queue, priority, max-attempts, and schedule options
 - storing jobs in PostgreSQL and atomically claiming runnable jobs per queue
+- inspecting persisted jobs through a typed admin query API
 - polling queues automatically and dispatching claimed jobs through supervised runners
 - cancelling queued jobs before execution
+- manually retrying discarded or cancelled jobs through a typed admin API
 - retrying failed jobs with configurable backoff
 - recovering stale `executing` jobs back into a runnable or terminal state
 
-Kairos on `main` does not yet provide a full operational surface for inspection, telemetry, pruning, or advanced queue controls. The runtime is useful now, but still intentionally narrow.
+Kairos on `main` does not yet provide a full operational surface for telemetry, pruning, or advanced queue controls. The runtime is useful now, but still intentionally narrow.
 
 ## Docs
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,7 @@ Kairos is a PostgreSQL-backed background job runtime with four main layers:
 The public boundary is intentionally small:
 
 - `kairos.gleam` exposes startup, enqueue, cancellation, and stale recovery
+- `admin.gleam` exposes typed job inspection plus explicit retry and cancellation admin helpers
 - `config.gleam` owns queue and worker registration for a runtime instance
 - `job.gleam`, `worker.gleam`, `queue.gleam`, and `backoff.gleam` define the typed domain model
 
@@ -185,8 +186,10 @@ This gives the recovery path these properties:
 
 - `src/kairos.gleam`
   Owns the package-level API for start, enqueue, cancel, and stale recovery.
+- `src/kairos/admin.gleam`
+  Owns typed job inspection and explicit admin mutations over persisted jobs.
 - `src/kairos/job.gleam`
-  Owns job state and enqueue options.
+  Owns job state, enqueue options, and inspection-facing job snapshots.
 - `src/kairos/worker.gleam`
   Owns typed worker contracts, payload decoding, and perform results.
 - `src/kairos/queue.gleam`
@@ -245,8 +248,8 @@ The current folder structure is still clean enough to scale if new work follows 
 
 ## Current Pressure Points
 
-- `kairos.gleam` is growing into a package facade for multiple operational APIs.
+- the admin surface is still intentionally small and may need pagination or richer filters later
 - Logging and telemetry are still minimal.
-- Admin and inspection APIs are not yet first-class.
+- pruning and advanced queue controls are not yet first-class.
 
 Those are still acceptable at the current maturity level, but future work should avoid collapsing more runtime details into the top-level package module.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,9 +14,11 @@ Kairos is a PostgreSQL-backed background job runtime with four main layers:
 The public boundary is intentionally small:
 
 - `kairos.gleam` exposes startup, enqueue, cancellation, and stale recovery
-- `admin.gleam` exposes job inspection plus explicit retry and cancellation admin helpers
+- `admin.gleam` exposes bounded job inspection plus explicit retry and cancellation admin helpers
 - `config.gleam` owns queue and worker registration for a runtime instance
 - `job.gleam`, `worker.gleam`, `queue.gleam`, and `backoff.gleam` define the domain model
+
+Admin job inspection is intentionally bounded. `admin.new_query()` applies a default result limit, and callers can override it explicitly when they need a different batch size.
 
 The runtime boundary is explicit:
 
@@ -71,6 +73,8 @@ stateDiagram-v2
     Pending --> Cancelled
     Scheduled --> Cancelled
     Retryable --> Cancelled
+    Discarded --> Pending: admin retry
+    Cancelled --> Pending: admin retry
 ```
 
 ## Scheduling Algorithm

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,9 +14,9 @@ Kairos is a PostgreSQL-backed background job runtime with four main layers:
 The public boundary is intentionally small:
 
 - `kairos.gleam` exposes startup, enqueue, cancellation, and stale recovery
-- `admin.gleam` exposes typed job inspection plus explicit retry and cancellation admin helpers
+- `admin.gleam` exposes job inspection plus explicit retry and cancellation admin helpers
 - `config.gleam` owns queue and worker registration for a runtime instance
-- `job.gleam`, `worker.gleam`, `queue.gleam`, and `backoff.gleam` define the typed domain model
+- `job.gleam`, `worker.gleam`, `queue.gleam`, and `backoff.gleam` define the domain model
 
 The runtime boundary is explicit:
 
@@ -187,7 +187,7 @@ This gives the recovery path these properties:
 - `src/kairos.gleam`
   Owns the package-level API for start, enqueue, cancel, and stale recovery.
 - `src/kairos/admin.gleam`
-  Owns typed job inspection and explicit admin mutations over persisted jobs.
+  Owns job inspection and explicit admin mutations over persisted jobs.
 - `src/kairos/job.gleam`
   Owns job state, enqueue options, and inspection-facing job snapshots.
 - `src/kairos/worker.gleam`
@@ -233,7 +233,7 @@ This gives the recovery path these properties:
 
 The current folder structure is still clean enough to scale if new work follows these rules:
 
-1. Keep typed domain concepts in `src/kairos/*.gleam`.
+1. Keep domain concepts in `src/kairos/*.gleam`.
 2. Keep process orchestration in runtime modules, not in `kairos.gleam`.
 3. Keep SQL and row decoding inside `src/kairos/postgres`.
 4. Keep queue polling, dispatch, execution, and stale recovery as separate concerns.

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -17,7 +17,7 @@ Kairos is already usable, but it is not yet a full operational platform.
 
 Current gaps include:
 
-- rich admin and query APIs
+- broader admin and query APIs
 - telemetry and structured runtime events
 - automatic job pruning and retention policies
 - advanced queue controls such as pause, drain, or scaling behavior

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -4,7 +4,7 @@ Kairos is a `0.x` background job runner for Gleam.
 
 ## What Kairos Already Does
 
-- defines typed workers with explicit encode and decode boundaries
+- defines workers with explicit encode and decode boundaries
 - persists jobs in PostgreSQL
 - supports per-queue polling and supervised execution
 - retries failed jobs with configurable backoff
@@ -33,7 +33,7 @@ Current gaps include:
 
 Kairos is a good fit today if you want:
 
-- typed background jobs in a Gleam application
+- background jobs in a Gleam application
 - PostgreSQL-backed persistence
 - a runtime you can understand end to end
 - a narrower feature set with room to evolve

--- a/src/kairos/admin.gleam
+++ b/src/kairos/admin.gleam
@@ -15,6 +15,10 @@ pub type QueryError {
   QueryUnexpectedStoredRowCount(expected: Int, actual: Int)
 }
 
+pub type QueryOptionError {
+  NonPositiveLimit
+}
+
 pub type RetryError {
   JobNotFound(String)
   JobNotRetryable(job.JobState)
@@ -29,67 +33,105 @@ pub opaque type Query {
     queue_name: Option(String),
     worker_name: Option(String),
     states: List(job.JobState),
+    limit: Int,
   )
 }
 
 pub fn new_query() -> Query {
-  Query(id: None, queue_name: None, worker_name: None, states: [])
+  Query(
+    id: None,
+    queue_name: None,
+    worker_name: None,
+    states: [],
+    limit: default_query_limit(),
+  )
 }
 
 pub fn with_id(query: Query, id: String) -> Query {
-  let Query(queue_name:, worker_name:, states:, ..) = query
+  let Query(queue_name:, worker_name:, states:, limit:, ..) = query
   Query(
     id: Some(id),
     queue_name: queue_name,
     worker_name: worker_name,
     states: states,
+    limit: limit,
   )
 }
 
 pub fn with_queue(query: Query, queue_name: String) -> Query {
-  let Query(id:, worker_name:, states:, ..) = query
+  let Query(id:, worker_name:, states:, limit:, ..) = query
   Query(
     id: id,
     queue_name: Some(queue_name),
     worker_name: worker_name,
     states: states,
+    limit: limit,
   )
 }
 
 pub fn with_worker(query: Query, worker_name: String) -> Query {
-  let Query(id:, queue_name:, states:, ..) = query
+  let Query(id:, queue_name:, states:, limit:, ..) = query
   Query(
     id: id,
     queue_name: queue_name,
     worker_name: Some(worker_name),
     states: states,
+    limit: limit,
   )
 }
 
 pub fn with_state(query: Query, state: job.JobState) -> Query {
-  let Query(id:, queue_name:, worker_name:, ..) = query
-  Query(id: id, queue_name: queue_name, worker_name: worker_name, states: [
-    state,
-  ])
+  let Query(id:, queue_name:, worker_name:, limit:, ..) = query
+  Query(
+    id: id,
+    queue_name: queue_name,
+    worker_name: worker_name,
+    states: [state],
+    limit: limit,
+  )
 }
 
 pub fn with_states(query: Query, states: List(job.JobState)) -> Query {
-  let Query(id:, queue_name:, worker_name:, ..) = query
+  let Query(id:, queue_name:, worker_name:, limit:, ..) = query
   Query(
     id: id,
     queue_name: queue_name,
     worker_name: worker_name,
     states: states,
+    limit: limit,
   )
+}
+
+pub fn with_limit(query: Query, limit: Int) -> Result(Query, QueryOptionError) {
+  case limit <= 0 {
+    True -> Error(NonPositiveLimit)
+    False -> {
+      let Query(id:, queue_name:, worker_name:, states:, ..) = query
+      Ok(Query(
+        id: id,
+        queue_name: queue_name,
+        worker_name: worker_name,
+        states: states,
+        limit: limit,
+      ))
+    }
+  }
 }
 
 pub fn list(
   config: config.Config,
   query: Query,
 ) -> Result(List(job.JobSnapshot), QueryError) {
-  let Query(id:, queue_name:, worker_name:, states:) = query
+  let Query(id:, queue_name:, worker_name:, states:, limit:) = query
 
-  job_store.list(config.connection(config), id, queue_name, worker_name, states)
+  job_store.list(
+    config.connection(config),
+    id,
+    queue_name,
+    worker_name,
+    states,
+    limit,
+  )
   |> result.map(list_from_persisted)
   |> result.map_error(map_query_store_error)
 }
@@ -151,6 +193,10 @@ fn can_retry(state: job.JobState) -> Bool {
     job.Cancelled -> True
     _ -> False
   }
+}
+
+fn default_query_limit() -> Int {
+  100
 }
 
 fn list_from_persisted(

--- a/src/kairos/admin.gleam
+++ b/src/kairos/admin.gleam
@@ -1,0 +1,236 @@
+//// Administrative APIs for inspecting and mutating persisted Kairos jobs.
+
+import gleam/option.{type Option, None, Some}
+import gleam/result
+import gleam/time/timestamp
+import kairos
+import kairos/config
+import kairos/job
+import kairos/postgres/job_store
+import pog
+
+pub type QueryError {
+  QueryStoreQueryFailed
+  QueryInvalidStoredState(String)
+  QueryUnexpectedStoredRowCount(expected: Int, actual: Int)
+}
+
+pub type RetryError {
+  JobNotFound(String)
+  JobNotRetryable(job.JobState)
+  RetryStoreQueryFailed
+  RetryInvalidStoredState(String)
+  RetryUnexpectedStoredRowCount(expected: Int, actual: Int)
+}
+
+pub opaque type Query {
+  Query(
+    id: Option(String),
+    queue_name: Option(String),
+    worker_name: Option(String),
+    states: List(job.JobState),
+  )
+}
+
+pub fn new_query() -> Query {
+  Query(id: None, queue_name: None, worker_name: None, states: [])
+}
+
+pub fn with_id(query: Query, id: String) -> Query {
+  let Query(queue_name:, worker_name:, states:, ..) = query
+  Query(
+    id: Some(id),
+    queue_name: queue_name,
+    worker_name: worker_name,
+    states: states,
+  )
+}
+
+pub fn with_queue(query: Query, queue_name: String) -> Query {
+  let Query(id:, worker_name:, states:, ..) = query
+  Query(
+    id: id,
+    queue_name: Some(queue_name),
+    worker_name: worker_name,
+    states: states,
+  )
+}
+
+pub fn with_worker(query: Query, worker_name: String) -> Query {
+  let Query(id:, queue_name:, states:, ..) = query
+  Query(
+    id: id,
+    queue_name: queue_name,
+    worker_name: Some(worker_name),
+    states: states,
+  )
+}
+
+pub fn with_state(query: Query, state: job.JobState) -> Query {
+  let Query(id:, queue_name:, worker_name:, ..) = query
+  Query(id: id, queue_name: queue_name, worker_name: worker_name, states: [
+    state,
+  ])
+}
+
+pub fn with_states(query: Query, states: List(job.JobState)) -> Query {
+  let Query(id:, queue_name:, worker_name:, ..) = query
+  Query(
+    id: id,
+    queue_name: queue_name,
+    worker_name: worker_name,
+    states: states,
+  )
+}
+
+pub fn list(
+  config: config.Config,
+  query: Query,
+) -> Result(List(job.JobSnapshot), QueryError) {
+  let Query(id:, queue_name:, worker_name:, states:) = query
+
+  job_store.list(config.connection(config), id, queue_name, worker_name, states)
+  |> result.map(list_from_persisted)
+  |> result.map_error(map_query_store_error)
+}
+
+pub fn cancel(
+  config: config.Config,
+  id: String,
+) -> Result(Nil, kairos.CancelError) {
+  kairos.cancel(config, id)
+}
+
+pub fn cancel_at(
+  config: config.Config,
+  id: String,
+  now: timestamp.Timestamp,
+) -> Result(Nil, kairos.CancelError) {
+  kairos.cancel_at(config, id, now)
+}
+
+pub fn retry(config: config.Config, id: String) -> Result(Nil, RetryError) {
+  retry_at(config, id, timestamp.system_time())
+}
+
+pub fn retry_at(
+  config: config.Config,
+  id: String,
+  now: timestamp.Timestamp,
+) -> Result(Nil, RetryError) {
+  pog.transaction(config.connection(config), fn(connection) {
+    let fetched =
+      job_store.fetch_for_update(connection, id)
+      |> result.map_error(map_retry_store_error)
+    use fetched <- result.try(fetched)
+
+    case fetched {
+      None -> Error(JobNotFound(id))
+      Some(persisted_job) -> {
+        let job_store.PersistedJob(state:, ..) = persisted_job
+
+        case can_retry(state) {
+          True -> {
+            let retried =
+              job_store.retry_now(connection, id, now)
+              |> result.map_error(map_retry_store_error)
+            use _ <- result.try(retried)
+            Ok(Nil)
+          }
+          False -> Error(JobNotRetryable(state))
+        }
+      }
+    }
+  })
+  |> map_retry_transaction_error
+}
+
+fn can_retry(state: job.JobState) -> Bool {
+  case state {
+    job.Discarded -> True
+    job.Cancelled -> True
+    _ -> False
+  }
+}
+
+fn list_from_persisted(
+  persisted_jobs: List(job_store.PersistedJob),
+) -> List(job.JobSnapshot) {
+  case persisted_jobs {
+    [] -> []
+    [persisted_job, ..rest] -> [
+      from_persisted(persisted_job),
+      ..list_from_persisted(rest)
+    ]
+  }
+}
+
+fn from_persisted(persisted_job: job_store.PersistedJob) -> job.JobSnapshot {
+  let job_store.PersistedJob(
+    id: id,
+    worker_name: worker_name,
+    payload: payload,
+    state: state,
+    queue_name: queue_name,
+    priority: priority,
+    attempt: attempt,
+    max_attempts: max_attempts,
+    unique_key: unique_key,
+    errors: errors,
+    scheduled_at: scheduled_at,
+    attempted_at: attempted_at,
+    completed_at: completed_at,
+    discarded_at: discarded_at,
+    cancelled_at: cancelled_at,
+    inserted_at: inserted_at,
+    updated_at: updated_at,
+  ) = persisted_job
+
+  job.JobSnapshot(
+    id: id,
+    worker_name: worker_name,
+    payload: payload,
+    state: state,
+    queue_name: queue_name,
+    priority: priority,
+    attempt: attempt,
+    max_attempts: max_attempts,
+    unique_key: unique_key,
+    errors: errors,
+    scheduled_at: scheduled_at,
+    attempted_at: attempted_at,
+    completed_at: completed_at,
+    discarded_at: discarded_at,
+    cancelled_at: cancelled_at,
+    inserted_at: inserted_at,
+    updated_at: updated_at,
+  )
+}
+
+fn map_query_store_error(error: job_store.StoreError) -> QueryError {
+  case error {
+    job_store.QueryFailed(_) -> QueryStoreQueryFailed
+    job_store.InvalidJobState(state) -> QueryInvalidStoredState(state)
+    job_store.UnexpectedRowCount(expected:, actual:) ->
+      QueryUnexpectedStoredRowCount(expected: expected, actual: actual)
+  }
+}
+
+fn map_retry_transaction_error(
+  result: Result(Nil, pog.TransactionError(RetryError)),
+) -> Result(Nil, RetryError) {
+  case result {
+    Ok(value) -> Ok(value)
+    Error(pog.TransactionQueryError(_)) -> Error(RetryStoreQueryFailed)
+    Error(pog.TransactionRolledBack(error)) -> Error(error)
+  }
+}
+
+fn map_retry_store_error(error: job_store.StoreError) -> RetryError {
+  case error {
+    job_store.QueryFailed(_) -> RetryStoreQueryFailed
+    job_store.InvalidJobState(state) -> RetryInvalidStoredState(state)
+    job_store.UnexpectedRowCount(expected:, actual:) ->
+      RetryUnexpectedStoredRowCount(expected: expected, actual: actual)
+  }
+}

--- a/src/kairos/job.gleam
+++ b/src/kairos/job.gleam
@@ -58,6 +58,28 @@ pub type EnqueuedJob(args) {
   )
 }
 
+pub type JobSnapshot {
+  JobSnapshot(
+    id: String,
+    worker_name: String,
+    payload: String,
+    state: JobState,
+    queue_name: String,
+    priority: Int,
+    attempt: Int,
+    max_attempts: Int,
+    unique_key: Option(String),
+    errors: List(String),
+    scheduled_at: timestamp.Timestamp,
+    attempted_at: Option(timestamp.Timestamp),
+    completed_at: Option(timestamp.Timestamp),
+    discarded_at: Option(timestamp.Timestamp),
+    cancelled_at: Option(timestamp.Timestamp),
+    inserted_at: timestamp.Timestamp,
+    updated_at: timestamp.Timestamp,
+  )
+}
+
 pub fn default_enqueue_options() -> EnqueueOptions {
   EnqueueOptions(
     queue: "default",

--- a/src/kairos/postgres/job_store.gleam
+++ b/src/kairos/postgres/job_store.gleam
@@ -137,6 +137,7 @@ pub fn list(
   queue_name_filter: Option(String),
   worker_name_filter: Option(String),
   state_filters: List(job.JobState),
+  limit: Int,
 ) -> Result(List(PersistedJob), StoreError) {
   let state_names = list.map(state_filters, job.state_name)
 
@@ -146,6 +147,7 @@ pub fn list(
   |> db.parameter(db.nullable(db.text, queue_name_filter))
   |> db.parameter(db.nullable(db.text, worker_name_filter))
   |> db.parameter(db.array(db.text, state_names))
+  |> db.parameter(db.int(limit))
   |> db.returning(raw_job.decoder())
   |> db.execute(connection)
   |> map_many_row_result

--- a/src/kairos/postgres/job_store.gleam
+++ b/src/kairos/postgres/job_store.gleam
@@ -1,5 +1,6 @@
 //// PostgreSQL persistence primitives for Kairos jobs.
 
+import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/time/timestamp
 import kairos/job
@@ -130,6 +131,26 @@ pub fn fetch_for_update(
   |> map_optional_row_result
 }
 
+pub fn list(
+  connection: db.Connection,
+  id_filter: Option(String),
+  queue_name_filter: Option(String),
+  worker_name_filter: Option(String),
+  state_filters: List(job.JobState),
+) -> Result(List(PersistedJob), StoreError) {
+  let state_names = list.map(state_filters, job.state_name)
+
+  query.list_filtered()
+  |> db.query
+  |> db.parameter(db.nullable(db.text, id_filter))
+  |> db.parameter(db.nullable(db.text, queue_name_filter))
+  |> db.parameter(db.nullable(db.text, worker_name_filter))
+  |> db.parameter(db.array(db.text, state_names))
+  |> db.returning(raw_job.decoder())
+  |> db.execute(connection)
+  |> map_many_row_result
+}
+
 pub fn fetch_available(
   connection: db.Connection,
   now: timestamp.Timestamp,
@@ -249,6 +270,20 @@ pub fn cancel_before_execution(
   |> db.parameter(db.text(id))
   |> db.parameter(db.timestamp(cancelled_at))
   |> db.parameter(db.text(error))
+  |> db.returning(raw_job.decoder())
+  |> db.execute(connection)
+  |> map_single_row_result
+}
+
+pub fn retry_now(
+  connection: db.Connection,
+  id: String,
+  scheduled_at: timestamp.Timestamp,
+) -> Result(PersistedJob, StoreError) {
+  query.retry_now()
+  |> db.query
+  |> db.parameter(db.text(id))
+  |> db.parameter(db.timestamp(scheduled_at))
   |> db.returning(raw_job.decoder())
   |> db.execute(connection)
   |> map_single_row_result

--- a/src/kairos/postgres/job_store/query.gleam
+++ b/src/kairos/postgres/job_store/query.gleam
@@ -63,7 +63,7 @@ pub fn list_filtered() -> String {
   SELECT
   " <> selected_columns("kairos_jobs") <> "
   FROM kairos_jobs
-  WHERE ($1::TEXT IS NULL OR id::TEXT = $1)
+  WHERE ($1::TEXT IS NULL OR id = ($1::TEXT)::UUID)
     AND ($2::TEXT IS NULL OR queue_name = $2)
     AND ($3::TEXT IS NULL OR worker_name = $3)
     AND (
@@ -71,6 +71,7 @@ pub fn list_filtered() -> String {
       OR state = ANY($4::TEXT[])
     )
   ORDER BY updated_at DESC, inserted_at DESC, id DESC
+  LIMIT $5
   "
 }
 
@@ -206,6 +207,7 @@ pub fn retry_now() -> String {
   SET
     state = 'pending',
     scheduled_at = $2,
+    attempted_at = NULL,
     completed_at = NULL,
     discarded_at = NULL,
     cancelled_at = NULL,

--- a/src/kairos/postgres/job_store/query.gleam
+++ b/src/kairos/postgres/job_store/query.gleam
@@ -58,6 +58,23 @@ pub fn fetch_for_update() -> String {
 }
 
 @internal
+pub fn list_filtered() -> String {
+  "
+  SELECT
+  " <> selected_columns("kairos_jobs") <> "
+  FROM kairos_jobs
+  WHERE ($1::TEXT IS NULL OR id::TEXT = $1)
+    AND ($2::TEXT IS NULL OR queue_name = $2)
+    AND ($3::TEXT IS NULL OR worker_name = $3)
+    AND (
+      COALESCE(array_length($4::TEXT[], 1), 0) = 0
+      OR state = ANY($4::TEXT[])
+    )
+  ORDER BY updated_at DESC, inserted_at DESC, id DESC
+  "
+}
+
+@internal
 pub fn fetch_available() -> String {
   "
   SELECT
@@ -179,6 +196,22 @@ pub fn cancel_before_execution() -> String {
     errors = array_append(kairos_jobs.errors, $3::TEXT)
   WHERE id = $1
     AND state IN ('pending', 'scheduled', 'retryable')
+  " <> returned_columns("kairos_jobs")
+}
+
+@internal
+pub fn retry_now() -> String {
+  "
+  UPDATE kairos_jobs
+  SET
+    state = 'pending',
+    scheduled_at = $2,
+    completed_at = NULL,
+    discarded_at = NULL,
+    cancelled_at = NULL,
+    max_attempts = GREATEST(kairos_jobs.max_attempts, kairos_jobs.attempt + 1)
+  WHERE id = $1
+    AND state IN ('discarded', 'cancelled')
   " <> returned_columns("kairos_jobs")
 }
 

--- a/test/kairos/admin_test.gleam
+++ b/test/kairos/admin_test.gleam
@@ -99,6 +99,30 @@ pub fn list_filters_jobs_by_id_queue_worker_and_state_test() {
     assert discarded_queue == "beta"
     assert discarded_payload == "beta-email"
 
+    let terminal_query =
+      admin.new_query() |> admin.with_states([job.Discarded, job.Retryable])
+    let assert Ok(terminal_jobs) = admin.list(kairos_config, terminal_query)
+    let terminal_ids =
+      terminal_jobs
+      |> list.map(fn(snapshot) {
+        let job.JobSnapshot(id:, ..) = snapshot
+        id
+      })
+    assert list.length(terminal_jobs) == 2
+    assert list.contains(terminal_ids, alpha_cleanup_id)
+    assert list.contains(terminal_ids, beta_email_id)
+
+    let all_query = admin.new_query() |> admin.with_states([])
+    let assert Ok(all_jobs) = admin.list(kairos_config, all_query)
+    assert list.length(all_jobs) == 3
+
+    let assert Ok(limited_query) =
+      admin.new_query()
+      |> admin.with_states([])
+      |> admin.with_limit(2)
+    let assert Ok(limited_jobs) = admin.list(kairos_config, limited_query)
+    assert list.length(limited_jobs) == 2
+
     let assert Ok([filtered_job]) =
       admin.list(
         kairos_config,
@@ -128,6 +152,15 @@ pub fn list_filters_jobs_by_id_queue_worker_and_state_test() {
     assert list.contains(returned_ids, alpha_cleanup_id)
     assert list.contains(returned_ids, beta_email_id) == False
   })
+}
+
+pub fn with_limit_rejects_non_positive_limits_test() {
+  let assert Error(admin.NonPositiveLimit) =
+    admin.new_query() |> admin.with_limit(0)
+  let assert Error(admin.NonPositiveLimit) =
+    admin.new_query() |> admin.with_limit(-1)
+
+  Nil
 }
 
 pub fn retry_at_requeues_cancelled_and_discarded_jobs_test() {
@@ -347,6 +380,7 @@ fn assert_retried(
     attempt: attempt,
     max_attempts: max_attempts,
     scheduled_at: scheduled_at,
+    attempted_at: attempted_at,
     completed_at: completed_at,
     discarded_at: discarded_at,
     cancelled_at: cancelled_at,
@@ -358,6 +392,7 @@ fn assert_retried(
   assert attempt == expected_attempt
   assert max_attempts == expected_max_attempts
   assert scheduled_at == expected_retry_at
+  assert attempted_at == None
   assert completed_at == None
   assert discarded_at == None
   assert cancelled_at == None

--- a/test/kairos/admin_test.gleam
+++ b/test/kairos/admin_test.gleam
@@ -1,0 +1,365 @@
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/time/timestamp
+import gleeunit
+import kairos/admin
+import kairos/config
+import kairos/job
+import kairos/postgres/job_store
+import kairos/postgres/test_db
+import kairos/queue
+import kairos/worker
+import pog
+
+type ExampleArgs {
+  ExampleArgs(name: String)
+}
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+pub fn list_filters_jobs_by_id_queue_worker_and_state_test() {
+  test_db.with_database(fn(connection) {
+    let kairos_config = build_config(connection)
+    let now = timestamp.system_time()
+    let alpha_email =
+      insert_job(
+        connection,
+        worker_name: "workers.email",
+        payload: "alpha-email",
+        state: job.Pending,
+        queue_name: "alpha",
+        attempt: 0,
+        max_attempts: 5,
+        scheduled_at: now,
+        errors: [],
+      )
+    let alpha_cleanup =
+      insert_job(
+        connection,
+        worker_name: "workers.cleanup",
+        payload: "alpha-cleanup",
+        state: job.Retryable,
+        queue_name: "alpha",
+        attempt: 2,
+        max_attempts: 5,
+        scheduled_at: now,
+        errors: ["kind=retry attempt=1 reason=temporary failure"],
+      )
+    let beta_email =
+      insert_job(
+        connection,
+        worker_name: "workers.email",
+        payload: "beta-email",
+        state: job.Discarded,
+        queue_name: "beta",
+        attempt: 3,
+        max_attempts: 3,
+        scheduled_at: now,
+        errors: ["kind=discard attempt=3 reason=permanent failure"],
+      )
+    let job_store.PersistedJob(id: alpha_cleanup_id, ..) = alpha_cleanup
+    let job_store.PersistedJob(id: alpha_email_id, ..) = alpha_email
+    let job_store.PersistedJob(id: beta_email_id, ..) = beta_email
+
+    let assert Ok(queue_jobs) =
+      admin.list(kairos_config, admin.new_query() |> admin.with_queue("alpha"))
+    assert list.length(queue_jobs) == 2
+    assert list.all(queue_jobs, fn(snapshot) {
+      let job.JobSnapshot(queue_name:, ..) = snapshot
+      queue_name == "alpha"
+    })
+
+    let assert Ok(worker_jobs) =
+      admin.list(
+        kairos_config,
+        admin.new_query() |> admin.with_worker("workers.email"),
+      )
+    assert list.length(worker_jobs) == 2
+    assert list.all(worker_jobs, fn(snapshot) {
+      let job.JobSnapshot(worker_name:, ..) = snapshot
+      worker_name == "workers.email"
+    })
+
+    let assert Ok([discarded_job]) =
+      admin.list(
+        kairos_config,
+        admin.new_query() |> admin.with_state(job.Discarded),
+      )
+    let job.JobSnapshot(
+      id: discarded_id,
+      state: discarded_state,
+      queue_name: discarded_queue,
+      payload: discarded_payload,
+      ..,
+    ) = discarded_job
+    assert discarded_id == beta_email_id
+    assert discarded_state == job.Discarded
+    assert discarded_queue == "beta"
+    assert discarded_payload == "beta-email"
+
+    let assert Ok([filtered_job]) =
+      admin.list(
+        kairos_config,
+        admin.new_query() |> admin.with_id(alpha_cleanup_id),
+      )
+    let job.JobSnapshot(
+      id: filtered_id,
+      state: filtered_state,
+      queue_name: filtered_queue,
+      worker_name: filtered_worker,
+      payload: filtered_payload,
+      ..,
+    ) = filtered_job
+    assert filtered_id == alpha_cleanup_id
+    assert filtered_state == job.Retryable
+    assert filtered_queue == "alpha"
+    assert filtered_worker == "workers.cleanup"
+    assert filtered_payload == "alpha-cleanup"
+
+    let returned_ids =
+      queue_jobs
+      |> list.map(fn(snapshot) {
+        let job.JobSnapshot(id:, ..) = snapshot
+        id
+      })
+    assert list.contains(returned_ids, alpha_email_id)
+    assert list.contains(returned_ids, alpha_cleanup_id)
+    assert list.contains(returned_ids, beta_email_id) == False
+  })
+}
+
+pub fn retry_at_requeues_cancelled_and_discarded_jobs_test() {
+  test_db.with_database(fn(connection) {
+    let kairos_config = build_config(connection)
+    let original_time = timestamp.system_time()
+    let discarded_job =
+      insert_job(
+        connection,
+        worker_name: "workers.discarded",
+        payload: "discarded",
+        state: job.Discarded,
+        queue_name: "default",
+        attempt: 3,
+        max_attempts: 3,
+        scheduled_at: original_time,
+        errors: ["kind=discard attempt=3 reason=permanent failure"],
+      )
+    let cancelled_job =
+      insert_job(
+        connection,
+        worker_name: "workers.cancelled",
+        payload: "cancelled",
+        state: job.Cancelled,
+        queue_name: "default",
+        attempt: 0,
+        max_attempts: 1,
+        scheduled_at: original_time,
+        errors: ["kind=cancel attempt=0 reason=cancelled before execution"],
+      )
+    let retry_at = timestamp.system_time()
+    let expected_retry_at = test_db.to_postgres_precision(retry_at)
+    let job_store.PersistedJob(id: discarded_id, ..) = discarded_job
+    let job_store.PersistedJob(id: cancelled_id, ..) = cancelled_job
+
+    let assert Ok(Nil) = admin.retry_at(kairos_config, discarded_id, retry_at)
+    let assert Ok(Nil) = admin.retry_at(kairos_config, cancelled_id, retry_at)
+
+    let assert Ok(Some(retried_discarded)) =
+      job_store.fetch(connection, discarded_id)
+    let assert Ok(Some(retried_cancelled)) =
+      job_store.fetch(connection, cancelled_id)
+
+    assert_retried(
+      retried_discarded,
+      expected_retry_at,
+      expected_attempt: 3,
+      expected_max_attempts: 4,
+      expected_errors: ["kind=discard attempt=3 reason=permanent failure"],
+    )
+    assert_retried(
+      retried_cancelled,
+      expected_retry_at,
+      expected_attempt: 0,
+      expected_max_attempts: 1,
+      expected_errors: [
+        "kind=cancel attempt=0 reason=cancelled before execution",
+      ],
+    )
+  })
+}
+
+pub fn retry_at_rejects_non_retryable_states_test() {
+  test_db.with_database(fn(connection) {
+    let kairos_config = build_config(connection)
+    let now = timestamp.system_time()
+    let pending_job =
+      insert_job(
+        connection,
+        worker_name: "workers.pending",
+        payload: "pending",
+        state: job.Pending,
+        queue_name: "default",
+        attempt: 0,
+        max_attempts: 5,
+        scheduled_at: now,
+        errors: [],
+      )
+    let completed_job =
+      insert_job(
+        connection,
+        worker_name: "workers.completed",
+        payload: "completed",
+        state: job.Completed,
+        queue_name: "default",
+        attempt: 1,
+        max_attempts: 5,
+        scheduled_at: now,
+        errors: [],
+      )
+    let job_store.PersistedJob(id: pending_id, ..) = pending_job
+    let job_store.PersistedJob(id: completed_id, ..) = completed_job
+
+    let assert Error(admin.JobNotRetryable(job.Pending)) =
+      admin.retry_at(kairos_config, pending_id, now)
+    let assert Error(admin.JobNotRetryable(job.Completed)) =
+      admin.retry_at(kairos_config, completed_id, now)
+
+    Nil
+  })
+}
+
+pub fn retry_at_returns_not_found_for_missing_jobs_test() {
+  test_db.with_database(fn(connection) {
+    let kairos_config = build_config(connection)
+    let missing_id = "00000000-0000-0000-0000-000000000000"
+
+    let assert Error(admin.JobNotFound(id)) =
+      admin.retry_at(kairos_config, missing_id, timestamp.system_time())
+    assert id == missing_id
+
+    Nil
+  })
+}
+
+fn build_config(connection: pog.Connection) -> config.Config {
+  let assert Ok(default_queue) =
+    queue.new(name: "default", concurrency: 5, poll_interval_ms: 1000)
+  let assert Ok(alpha_queue) =
+    queue.new(name: "alpha", concurrency: 5, poll_interval_ms: 1000)
+  let assert Ok(beta_queue) =
+    queue.new(name: "beta", concurrency: 5, poll_interval_ms: 1000)
+  let contract = example_worker()
+  let assert Ok(kairos_config) =
+    config.new(
+      connection: connection,
+      queues: [
+        default_queue,
+        alpha_queue,
+        beta_queue,
+      ],
+      workers: [worker.register(contract)],
+    )
+
+  kairos_config
+}
+
+fn example_worker() -> worker.Worker(ExampleArgs) {
+  worker.new(
+    "workers.example",
+    fn(args) {
+      let ExampleArgs(name:) = args
+      name
+    },
+    fn(payload) { Ok(ExampleArgs(name: payload)) },
+    fn(_args) { worker.Success },
+    job.default_enqueue_options(),
+  )
+}
+
+fn insert_job(
+  connection: pog.Connection,
+  worker_name worker_name: String,
+  payload payload: String,
+  state state: job.JobState,
+  queue_name queue_name: String,
+  attempt attempt: Int,
+  max_attempts max_attempts: Int,
+  scheduled_at scheduled_at: timestamp.Timestamp,
+  errors errors: List(String),
+) -> job_store.PersistedJob {
+  let assert Ok(persisted_job) =
+    job_store.insert(
+      connection,
+      job_store.JobInsert(
+        worker_name: worker_name,
+        payload: payload,
+        state: state,
+        queue_name: queue_name,
+        priority: 0,
+        attempt: attempt,
+        max_attempts: max_attempts,
+        unique_key: None,
+        errors: errors,
+        scheduled_at: scheduled_at,
+        attempted_at: attempted_at_for(state, scheduled_at, attempt),
+        completed_at: terminal_timestamp_for(state, job.Completed, scheduled_at),
+        discarded_at: terminal_timestamp_for(state, job.Discarded, scheduled_at),
+        cancelled_at: terminal_timestamp_for(state, job.Cancelled, scheduled_at),
+      ),
+    )
+
+  persisted_job
+}
+
+fn attempted_at_for(
+  state: job.JobState,
+  scheduled_at: timestamp.Timestamp,
+  attempt: Int,
+) -> Option(timestamp.Timestamp) {
+  case attempt > 0 || state == job.Executing {
+    True -> Some(scheduled_at)
+    False -> None
+  }
+}
+
+fn terminal_timestamp_for(
+  actual_state: job.JobState,
+  terminal_state: job.JobState,
+  timestamp: timestamp.Timestamp,
+) -> Option(timestamp.Timestamp) {
+  case actual_state == terminal_state {
+    True -> Some(timestamp)
+    False -> None
+  }
+}
+
+fn assert_retried(
+  persisted_job: job_store.PersistedJob,
+  expected_retry_at: timestamp.Timestamp,
+  expected_attempt expected_attempt: Int,
+  expected_max_attempts expected_max_attempts: Int,
+  expected_errors expected_errors: List(String),
+) -> Nil {
+  let job_store.PersistedJob(
+    state: state,
+    attempt: attempt,
+    max_attempts: max_attempts,
+    scheduled_at: scheduled_at,
+    completed_at: completed_at,
+    discarded_at: discarded_at,
+    cancelled_at: cancelled_at,
+    errors: errors,
+    ..,
+  ) = persisted_job
+
+  assert state == job.Pending
+  assert attempt == expected_attempt
+  assert max_attempts == expected_max_attempts
+  assert scheduled_at == expected_retry_at
+  assert completed_at == None
+  assert discarded_at == None
+  assert cancelled_at == None
+  assert errors == expected_errors
+}


### PR DESCRIPTION
## Summary
- add a dedicated `kairos/admin` module for typed job inspection and explicit admin mutations
- expose `job.JobSnapshot` instead of leaking storage rows, and add explicit filters for id, queue, worker, and state
- allow manual retries only from legal terminal states (`cancelled` and `discarded`) while preserving explicit state-transition rules
- document the new admin surface in the README and architecture guide

## Why
Issue #11 asks for a stable operational API that applications can use to inspect job state and apply safe mutations without direct SQL access. This PR adds that surface while keeping the boundary between domain types, public API, and PostgreSQL storage explicit.

## Validation
- `gleam format`
- `gleam test`
- interactive consumer-app verification from a `/tmp` smoke app against a dedicated local PostgreSQL database:
  - `kairos@admin:list/2`
  - `kairos@admin:cancel/2`
  - `kairos@admin:retry/2`

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin API to list/inspect persisted jobs with filters (ID, queue, worker, state) returning detailed job snapshots (timestamps, attempts, errors).
  * Admin endpoints to manually retry discarded or cancelled jobs.
  * Admin endpoints to cancel jobs.

* **Documentation**
  * README and docs updated to reflect a broader “background jobs” scope and to document the admin inspection/retry/cancel surface.

* **Tests**
  * Integration tests for admin listing, retry behavior, error cases, and limit validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->